### PR TITLE
bug fix

### DIFF
--- a/hooks/useImageURIs.js
+++ b/hooks/useImageURIs.js
@@ -64,6 +64,7 @@ const useImageURIs = (hats, chainId) => {
     if (
       imagesData !== undefined &&
       imagesData !== null &&
+      imagesData[0] !== null && // useContractReads returns with [null] at the beginning and then updates, TODO check if there's better fix
       hats !== undefined &&
       hats !== null &&
       !imagesLoading


### PR DESCRIPTION
the bug caused when `useContractReads` returns at first with a `[null]` array. Added a check for this case to prevent `validateImages` to run.