### PR TITLE
fix multicall for gnosis

### DIFF
--- a/lib/web3.js
+++ b/lib/web3.js
@@ -3,6 +3,7 @@ import { configureChains, createClient } from 'wagmi';
 import { goerli, polygon, gnosis } from 'wagmi/chains';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
+import { publicProvider } from 'wagmi/providers/public';
 
 import '@rainbow-me/rainbowkit/styles.css';
 
@@ -31,10 +32,23 @@ export const chainsColors = (chainId) => {
   return colors[chainId] || colors[5];
 };
 
+// gnosis chain object from wagmi doesn't include multicall contract details. This is a temporary fix
+const gnosisContract = {
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 21022491,
+    },
+  },
+};
+
+const gnosisExtended = { ...gnosis, ...gnosisContract };
+
 export const { chains, provider } = configureChains(
-  [goerli, gnosis, polygon],
+  [goerli, gnosisExtended, polygon],
   [
     alchemyProvider({ apiKey: ALCHEMY_ID || '' }),
+    publicProvider(),
     jsonRpcProvider({
       rpc: (localChain) => ({
         http: localChain.rpcUrls.default,


### PR DESCRIPTION
- extended the `gnosis` chain object from wagmi to include the properties of the multicall3 contract
- `jsonRpcProvider` was not working well for gnosis. Adding `publicProvider` to the providers list solved the problem