### PR TITLE
Handle hex hat index

### DIFF
--- a/lib/hats.js
+++ b/lib/hats.js
@@ -86,7 +86,7 @@ export function prettyIdToUrlId(id, topOnly = false) {
   if (children && !topOnly) {
     const childrenIds = _.split(children, '.');
     const test = _.map(childrenIds, (index) => {
-      return BigNumber.from(index).toString();
+      return BigNumber.from(`0x${index}`).toString();
     });
     const joined = _.join([treeId, ...test], '_');
     return joined;


### PR DESCRIPTION
The bug occurs when a hat has 10 or more children, and then the index becomes hexadecimal 