### PR TITLE
Fix images display

### DIFF
--- a/components/Hat/Hat.jsx
+++ b/components/Hat/Hat.jsx
@@ -369,7 +369,7 @@ const Hat = ({
                 maxHeight='75px'
                 maxWidth='75px'
                 fit='fit'
-              ></Image>
+              />
               {imageHover && (
                 <Icon
                   as={FaPencilAlt}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -150,7 +150,7 @@ const Home = ({
                         maxHeight='85px'
                         maxWidth='85px'
                         fit='fit'
-                      ></Image>
+                      />
                     </Box>
                     <Stack spacing={1} maxW='110px'>
                       <Text fontWeight={700} noOfLines={2}>

--- a/pages/trees/[chainId]/[treeId]/[hatId].jsx
+++ b/pages/trees/[chainId]/[treeId]/[hatId].jsx
@@ -250,7 +250,7 @@ const TreeDetails = ({ treeId, chainId, hatId, prettyHatId, initialData }) => {
                     maxHeight='200px'
                     maxWidth='200px'
                     fit='fit'
-                  ></Image>
+                  />
                 </Box>
                 <Stack spacing={4} w='60%'>
                   <Heading size='md'>Tree Details</Heading>


### PR DESCRIPTION
The initial bug was the image display in tree ID 1 of Polygon (RabbitHole). The images were properly populated only in the tree visualization, but not in the cards. This was fixed by using the Chakra Image component for image display instead of the Box component. 
Additionally, the PR adjusts the images to maintain their aspect ratio and fit to a maximum size:
current image display:
<img width="251" alt="Screenshot 2023-04-30 at 15 52 13" src="https://user-images.githubusercontent.com/81111572/235353926-40ed0521-6f26-4e99-97b0-8755c918f464.png">

after fix:
<img width="254" alt="Screenshot 2023-04-30 at 15 51 28" src="https://user-images.githubusercontent.com/81111572/235353890-5a647e87-c764-4728-b6ba-a273b95b4ce7.png">

@nintynick 
This is changing a bit the card design. Currently there's a square with a predefined size, which the image is stretched into without necessarily keeping the aspect ratio. The suggestion here is to keep the aspect ratio of every image, while having a max width and height to fit into. Will change if you think it was better previously 

