### PR TITLE
Fix linked hats images

### DIFF
--- a/gql/queries.js
+++ b/gql/queries.js
@@ -39,10 +39,12 @@ export const TREE_DETAILS_FRAGMENT_WITH_EVENTS = gql`
     parentOfTrees {
       id
       linkedToHat {
+        id
         prettyId
       }
     }
     linkedToHat {
+      id
       prettyId
       tree {
         id

--- a/hooks/useImageURIs.js
+++ b/hooks/useImageURIs.js
@@ -10,6 +10,8 @@ import { PINATA_GATEWAY_TOKEN } from '../lib/ipfs';
  * returns an object, mapping from hat id to image url.
  * uses multi call in order to call the "getImageURIForHat" function for every hat with one call.
  * for every url, checks if valid. If not, sets the image url to undefined.
+ * @param {string[]} hats Array of hat IDs
+ * @param {number} chainId Chain ID
  */
 const useImageURIs = (hats, chainId) => {
   const [data, setData] = useState({});

--- a/hooks/useTreeDetails.js
+++ b/hooks/useTreeDetails.js
@@ -10,16 +10,13 @@ const useTreeDetails = ({ treeId, chainId, hatId, initialData }) => {
     initialData,
   });
 
-  const { childOfTree, linkedToHat, parentOfTrees } = data || {};
+  const { linkedToHat, parentOfTrees } = data || {};
   const linkedHatIds = [];
   if (linkedToHat) {
-    linkedHatIds.push(linkedToHat.prettyId);
+    linkedHatIds.push(linkedToHat.id);
   }
   if (parentOfTrees) {
     linkedHatIds.push(...parentOfTrees.map((tree) => prettyIdToId(tree.id)));
-  }
-  if (childOfTree && childOfTree.id !== linkedToHat?.prettyId) {
-    linkedHatIds.push(childOfTree.id);
   }
 
   return { data, linkedHatIds, isLoading, error };

--- a/lib/hats.js
+++ b/lib/hats.js
@@ -41,24 +41,11 @@ export function toTreeStructure(data, hatIdToImage) {
     };
   });
 
-  // If the tree is also childOfTree, add it to the hatsArray as the root node
-  if (data?.childOfTree) {
-    hatsArray.push({
-      hatName: data.childOfTree.id,
-      hatParent: 'dummy',
-      imageURI: hatIdToImage[data.childOfTree.id],
-      treeId: data.childOfTree.id,
-    });
-  }
-
   // If the tree is linkedToHat, add it to the hatsArray with the childOfTree id as its parent
-  if (
-    data?.linkedToHat &&
-    data?.childOfTree?.id !== data?.linkedToHat?.prettyId
-  ) {
+  if (data?.linkedToHat) {
     hatsArray.push({
       hatName: data.linkedToHat.prettyId,
-      hatParent: data.childOfTree?.id,
+      hatParent: 'dummy',
       imageURI: hatIdToImage[data.linkedToHat.id],
       treeId: data.linkedToHat.tree.id,
     });


### PR DESCRIPTION
- Include only direct linked hats in the visualization, without the rest of the hats in the parent/child tree. This is because the current implementation won't work when the hat in the parent tree is of level >= 2.
- Fix the image for the linked hats.