### PR TITLE
V1.2 QA fixes

### DIFF
--- a/components/Hat/HatWearers.jsx
+++ b/components/Hat/HatWearers.jsx
@@ -256,14 +256,10 @@ function HatWearers({ hatData, chainId, isAdminUser }) {
 
       <Stack align='center' spacing={4}>
         <Flex justify='space-between' w='100%'>
-          <HStack spacing={1}>
-            {_.get(hatData, 'currentSupply') &&
-              _.get(hatData, 'currentSupply') !==
-                _.get(hatData, 'maxSupply') && (
-                <Text>{_.get(hatData, 'currentSupply')} Worn /</Text>
-              )}
-            <Text>{_.get(hatData, 'maxSupply')} Max Supply</Text>
-          </HStack>
+          <Text>
+            {_.get(hatData, 'currentSupply')} Worn /{' '}
+            {_.get(hatData, 'maxSupply')} Max Supply
+          </Text>
 
           {address &&
             _.get(hatData, 'currentSupply') !== _.get(hatData, 'maxSupply') &&

--- a/components/TreeNode/TreeNode.jsx
+++ b/components/TreeNode/TreeNode.jsx
@@ -36,7 +36,6 @@ const HatHoverCard = ({
   isWearer,
   isWearerOrAdminOfHat,
   wearerHats,
-  handleLocalNodeClick,
   isCurrentHat,
 }) => {
   const wearer1 = _.get(_.first(_.get(hatData, 'wearers')), 'id');
@@ -92,8 +91,6 @@ const HatHoverCard = ({
       border='2px solid'
       borderColor={isCurrentHat ? '#437bc9' : '#6d858f'}
       borderRadius='md'
-      zIndex={5}
-      onClick={handleLocalNodeClick}
     >
       <Box w='100%' h='100%' position='relative'>
         <Box
@@ -271,7 +268,7 @@ function Node({
         }}
         onClick={handleLocalNodeClick}
       />
-      <foreignObject width={200} height={200} x={35} y={-25} overflow='visible'>
+      <foreignObject width={230} height={200} x={35} y={-25} overflow='visible'>
         <div
           style={{
             display: 'flex',


### PR DESCRIPTION
from #136, fixes:
- Hover card disappears when cursor is close to its border, but still on the card (on Firefox)
- Clicking on the three dots on the node hover card navigates to the hat and refocuses the visualization. Should only do that when clicking the node circle, not the card.
- On wearers tab, in case max hats were minted, should still show "k worn / n max supply"