### PR TITLE
Fix exporting image & manual/auto eligibility and toggle

### DIFF
--- a/contexts/TreeFormContext.tsx
+++ b/contexts/TreeFormContext.tsx
@@ -342,6 +342,7 @@ export const TreeFormContextProvider = ({
   const newImageUrls = useMemo(() => {
     return results.map((result, index) => ({
       id: storedHatsWithImage[index].id,
+      newImageUri: storedHatsWithImage[index].imageUrl,
       newImageUrl: result.data,
     }));
   }, [results, storedHatsWithImage]);
@@ -370,11 +371,13 @@ export const TreeFormContextProvider = ({
   const updatedTree = useMemo(() => {
     return _.map(filteredTree, (hat) => {
       const newImageUrl = _.find(newImageUrls, ['id', hat.id])?.newImageUrl;
+      const newImageUri = _.find(newImageUrls, ['id', hat.id])?.newImageUri;
       const newName = _.find(storedData, ['id', hat.id])?.name;
       return {
         ...hat,
         newName,
         newImageUrl,
+        newImageUri,
       };
     });
   }, [filteredTree, newImageUrls, storedData]);

--- a/lib/form.ts
+++ b/lib/form.ts
@@ -13,7 +13,7 @@ import {
 } from '@/types';
 
 import { createHierarchy, getDefaultAdminId } from './hats';
-import { calculateCid, ipfsUrl } from './ipfs';
+import { calculateCid, ipfsUrl, urlToIpfsUri } from './ipfs';
 import { createHatsClient } from './web3';
 
 const hasDetailsChanged = (
@@ -449,17 +449,23 @@ const processImageChangeCallForHat = async ({
 
   if (!hatId || !imageUrl) return returnData;
 
+  const imageUri = imageUrl.startsWith('https://')
+    ? urlToIpfsUri(imageUrl)
+    : imageUrl;
+
+  if (!imageUri) return returnData;
+
   const changeHatImageUriData = hatsClient.changeHatImageURICallData({
     hatId: BigInt(hatId),
-    newImageURI: imageUrl,
+    newImageURI: imageUri,
   });
 
   if (!changeHatImageUriData) return returnData;
 
   const newHatChanges = {
     ...hatChanges,
-    imageUri: imageUrl,
-    imageUrl: imageUrl ? ipfsUrl(imageUrl?.slice(7)) : '/icon.jpeg',
+    imageUri,
+    imageUrl: imageUri ? ipfsUrl(imageUri) : '/icon.jpeg',
   };
 
   return {

--- a/lib/hats.ts
+++ b/lib/hats.ts
@@ -15,6 +15,7 @@ import {
 } from '@/types';
 
 import { formatImageUrl, isImageUrl } from './general';
+import { ipfsUrl } from './ipfs';
 
 export const calculateNextChildId = (id: string, hatsData: Hat[]) => {
   const children = _.filter(
@@ -417,16 +418,19 @@ export const exportToCsv = (hatWearers: HatWearer[], hatName?: string) => {
 
 // Helper function for exporting tree data
 const mergeHatsWithStoredData = (
-  hats: FormData[],
+  hats: any[],
   storedData: Partial<FormData>[] | undefined,
 ) => {
   return _.map(hats, (hat) => {
     const storedHat = _.find(storedData, { id: hat.id });
-    const mergedHats = _.merge({}, hat, storedHat);
+    const mergedHat = _.merge({}, hat, storedHat);
+    const imageUri = storedHat?.imageUrl ?? (hat?.imageUri || '');
+    const imageUrl = ipfsUrl(imageUri?.slice(7));
     return {
-      ...mergedHats,
-      imageUrl: hat?.imageUrl === '/icon.jpeg' ? '' : hat?.imageUrl,
-      wearers: _.map(mergedHats.wearers, 'address') || [],
+      ...mergedHat,
+      imageUri,
+      imageUrl: hat?.imageUrl === '/icon.jpeg' ? '' : imageUrl,
+      wearers: _.map(mergedHat.wearers, 'address') || [],
     };
   });
 };
@@ -441,10 +445,10 @@ const prepareExportTree = (data: any[]): HatExport[] => {
     eligibility: hat.eligibility,
     toggle: hat.toggle,
     mutable: hat.mutable === MUTABILITY.MUTABLE,
-    imageUri: hat.imageUri,
     currentSupply: parseInt(hat.currentSupply, 10),
     wearers: hat.wearers,
     adminId: hat.adminId,
+    imageUri: hat.imageUri || '',
     imageUrl: hat.imageUrl || '',
     detailsObject: {
       type: '1.0',
@@ -536,7 +540,14 @@ const compareHatObjects = (hatA: any, hatB: any): any => {
   };
 
   _.forEach(hatA, (value, key) => {
-    if (_.includes(['createdAt', 'currentSupply'], key)) {
+    if (_.includes(['createdAt', 'currentSupply', 'imageUrl'], key)) {
+      return;
+    }
+
+    if (key === 'imageUri') {
+      if (!_.isEqual(String(value), String(hatB[key]))) {
+        diffHat.imageUrl = hatA.imageUrl;
+      }
       return;
     }
 
@@ -656,6 +667,7 @@ export const flattenHatData = (data: any[]): FormData[] =>
     wearers: extractWearers(hat.wearers),
     adminId: hat.adminId || _.get(hat, 'admin.id'),
     imageUrl: hat.imageUrl,
+    imageUri: hat.imageUri,
     name: _.get(hat, 'detailsObject.data.name'),
     description: _.get(hat, 'detailsObject.data.description'),
     responsibilities: _.get(hat, 'detailsObject.data.responsibilities', []),

--- a/lib/ipfs.ts
+++ b/lib/ipfs.ts
@@ -112,6 +112,11 @@ export const handleDetailsPin = async ({
 export const ipfsUrl = (hash: string) =>
   `${CONFIG.ipfsGateway}${hash}?pinataGatewayToken=${PINATA_GATEWAY_TOKEN}`;
 
+export const urlToIpfsUri = (url: string) => {
+  const match = url.match(/ipfs\/([a-zA-Z0-9]+)/);
+  return match ? `ipfs://${match[1]}` : null;
+};
+
 export const fetchDetailsIpfs = async (detailsField: string | undefined) => {
   if (!detailsField) return null;
   const url = ipfsUrl(detailsField?.slice(7));


### PR DESCRIPTION
- images with no changes got exported as `imgUrl: '/icon.jpeg'` - they now get exported as `''` (same as form's default value)
- `isEligibilityManual` and `isToggleManual` are now set to their string values when flattening the data & comparing it in form, so either `'Manually'` or `'Automatically'`. they are exported as boolean, same as before, e.g. `hat.isToggleManual === TRIGGER_OPTIONS.MANUALLY`

closes #645 