### PR TITLE
Persist flip and compact state with query params

### DIFF
--- a/components/OrgChart.tsx
+++ b/components/OrgChart.tsx
@@ -52,6 +52,8 @@ const OrgChartComponent: React.FC = () => {
     selectedOption,
     selectedHat,
     handleSelectHat,
+    handleFlipChart,
+    handleSetCompact,
     isLoading,
     storedData,
     setStoredData,
@@ -67,7 +69,15 @@ const OrgChartComponent: React.FC = () => {
     chainId,
     editMode,
   });
-  const { isOpen: compact, onToggle: toggleCompact } = useDisclosure();
+  const queryParams = new URLSearchParams(window.location.search);
+  const initialCompact = queryParams.get('compact') === 'true';
+  const initialFlipped = queryParams.get('flipped') === 'true';
+  const { isOpen: compact, onToggle: toggleCompact } = useDisclosure({
+    defaultIsOpen: initialCompact,
+  });
+  const { isOpen: flipped, onToggle: toggleFlip } = useDisclosure({
+    defaultIsOpen: initialFlipped,
+  });
 
   useLayoutEffect(() => {
     if (_.isEmpty(treeToDisplay)) return;
@@ -593,6 +603,7 @@ const OrgChartComponent: React.FC = () => {
           })
           .compact(compact)
           .render()
+          .layout(flipped ? 'bottom' : 'top')
           .expandAll();
 
         if (initialLoad) {
@@ -624,6 +635,7 @@ const OrgChartComponent: React.FC = () => {
     newImageUrls,
     treeToDisplay,
     compact,
+    flipped,
   ]);
 
   return isLoading ? (
@@ -656,11 +668,27 @@ const OrgChartComponent: React.FC = () => {
           Show full {CONFIG.tree}
         </Button>
         <Button
-          onClick={toggleCompact}
+          onClick={() => {
+            toggleCompact();
+            handleSetCompact?.(!compact);
+          }}
           variant='outline'
           bg={editMode ? '#C4F1F9' : 'whiteAlpha.800'}
         >
           {compact ? 'Full View' : 'Compact View'}
+        </Button>
+        <Button
+          onClick={() => {
+            toggleFlip();
+            handleFlipChart?.(!flipped);
+            setTimeout(() => {
+              chart?.fit();
+            }, 50);
+          }}
+          variant='outline'
+          bg={editMode ? '#C4F1F9' : 'whiteAlpha.800'}
+        >
+          Flip Tree
         </Button>
       </HStack>
 

--- a/contexts/TreeFormContext.tsx
+++ b/contexts/TreeFormContext.tsx
@@ -84,6 +84,8 @@ export interface TreeFormContext {
   // actions
   addHat: ((hat: Hat) => void) | undefined;
   handleSelectHat: ((id: Hex) => void) | undefined;
+  handleFlipChart: ((isFlipped: boolean) => void) | undefined;
+  handleSetCompact: ((isCompact: boolean) => void) | undefined;
   removeHat: ((hatId: Hex) => void) | undefined;
   resetTree: (() => void) | undefined;
   importHats: ((hats: Partial<FormData>[]) => void) | undefined;
@@ -128,6 +130,8 @@ export const treeFormContext = createContext<TreeFormContext>({
   setShowInactiveHats: undefined,
   // actions
   handleSelectHat: undefined,
+  handleFlipChart: undefined,
+  handleSetCompact: undefined,
   addHat: undefined,
   removeHat: undefined,
   resetTree: undefined,
@@ -436,6 +440,44 @@ export const TreeFormContextProvider = ({
     [orgChartTree, isMobile],
   );
 
+  const handleFlipChart = useCallback((isFlipped: boolean) => {
+    let updatedQuery = {
+      ...router.query,
+    };
+
+    if (isFlipped) {
+      updatedQuery = { ...updatedQuery, flipped: 'true' };
+    } else {
+      delete updatedQuery.flipped;
+    }
+
+    const updatedUrl = {
+      pathname: router.pathname,
+      query: updatedQuery,
+    };
+
+    router.push(updatedUrl, undefined, { shallow: true });
+  }, []);
+
+  const handleSetCompact = useCallback((isCompact: boolean) => {
+    let updatedQuery = {
+      ...router.query,
+    };
+
+    if (isCompact) {
+      updatedQuery = { ...updatedQuery, compact: 'true' };
+    } else {
+      delete updatedQuery.compact;
+    }
+
+    const updatedUrl = {
+      pathname: router.pathname,
+      query: updatedQuery,
+    };
+
+    router.push(updatedUrl, undefined, { shallow: true });
+  }, []);
+
   const toggleEditMode = useCallback(() => {
     if (!editMode) {
       const localDraftHats = _.reject(
@@ -619,6 +661,8 @@ export const TreeFormContextProvider = ({
       setShowInactiveHats,
       // actions
       handleSelectHat,
+      handleFlipChart,
+      handleSetCompact,
       addHat,
       removeHat,
       resetTree,
@@ -664,6 +708,8 @@ export const TreeFormContextProvider = ({
       setShowInactiveHats,
       // actions
       handleSelectHat,
+      handleFlipChart,
+      handleSetCompact,
       addHat,
       removeHat,
       resetTree,


### PR DESCRIPTION
- closes #580
- closes #661 

if user sets flipped or compact version of the chart, we add query params `flipped=true` or `compact=true`, if they reset it, we simply remove the params.

after flipping, we also re-centre the chart


https://github.com/Hats-Protocol/hats-anchor-app/assets/35112939/746f6161-ff4f-4d71-bcb7-fe19584a0efa

