### PR TITLE
Handle collapsed/expanded state as URL params

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -14,4 +14,4 @@ The build artifacts will be stored in the `{ROOT_DIR}/dist/` directory, ready to
 
 ## Caveat
 
-Building with the libraries requires a change in the app also to actually build the respective app deploy .
+Building with the libraries requires a change in the app also to actually build the respective app deploy.

--- a/libs/ui/src/molecules/OrgChart/OrgChart.tsx
+++ b/libs/ui/src/molecules/OrgChart/OrgChart.tsx
@@ -700,6 +700,8 @@ const OrgChartComponent: React.FC = () => {
 
       if (editMode) {
         chart.expandAll(); // keep nodes expanded on edit mode. Note that expandAll performs a render so no need to call render again
+      } else if (collapsedNodes.length === 0) {
+        chart.expandAll();
       } else if (initialLoad.current) {
         // initial rendering with collapsed nodes
         if (chartNodes !== undefined) {
@@ -717,8 +719,6 @@ const OrgChartComponent: React.FC = () => {
         }
         chart.render();
         recreateNodesCollapse(chart, collapsedNodes);
-      } else if (collapsedNodes.length === 0) {
-        chart.expandAll();
       } else {
         chart.render();
       }


### PR DESCRIPTION
This PR adds persistence of collapsed/expanded nodes state in query params and local storage. Few notes:
- Query params take precedence over locals storage
- Nodes are expanded when getting into edit mode and out of edit mode