### PR TITLE
Update ancillary subgraphs

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -14,4 +14,4 @@ The build artifacts will be stored in the `{ROOT_DIR}/dist/` directory, ready to
 
 ## Caveat
 
-Building with the libraries requires a change in the app also to actually build the respective app deploy .
+Building with the libraries requires a change in the app also to actually build the respective app deploy.


### PR DESCRIPTION
Use v0.0.13 ancillary subgraphs - includes a fix for MHSG indexing.