### PR TITLE
update ancillary subgraphs

### DIFF
--- a/libs/constants/src/subgraph.ts
+++ b/libs/constants/src/subgraph.ts
@@ -36,12 +36,12 @@ export const NETWORK_ENDPOINTS: EndpointsConfig = {
 export const ANCILLARY_API_URL: {
   [key in SupportedChains]: string | undefined;
 } = {
-  1: studioUrl('hats-v1-ethereum-ancillary', 'v0.0.23'),
-  10: studioUrl('hats-v1-optimism-ancillary', 'v0.0.23'),
-  100: studioUrl('hats-v1-gnosis-chain-ancillary', 'v0.0.23'),
-  137: studioUrl('hats-v1-polygon-ancillary', 'v0.0.23'),
-  8453: studioUrl('hats-v1-base-ancillary', 'v0.0.24'),
-  42161: studioUrl('hats-v1-arbitrum-ancillary', 'v0.0.23'),
-  42220: studioUrl('hats-v1-celo-ancillary', 'v0.0.24'),
-  11155111: studioUrl('hats-v1-sepolia-ancillary', 'v0.0.24'),
+  1: studioUrl('hats-v1-ethereum-ancillary', 'v0.0.24'),
+  10: studioUrl('hats-v1-optimism-ancillary', 'v0.0.24'),
+  100: studioUrl('hats-v1-gnosis-chain-ancillary', 'v0.0.24'),
+  137: studioUrl('hats-v1-polygon-ancillary', 'v0.0.24'),
+  8453: studioUrl('hats-v1-base-ancillary', 'v0.0.25'),
+  42161: studioUrl('hats-v1-arbitrum-ancillary', 'v0.0.24'),
+  42220: studioUrl('hats-v1-celo-ancillary', 'v0.0.25'),
+  11155111: studioUrl('hats-v1-sepolia-ancillary', 'v0.0.25'),
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated ancillary API URL versions for multiple blockchain networks, including:
		- Ethereum (chain 1)
		- Optimism (chain 10)
		- Gnosis Chain (chain 100)
		- Polygon (chain 137)
		- Base (chain 8453)
		- Arbitrum (chain 42161)
		- Celo (chain 42220)
		- Sepolia Testnet (chain 11155111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->