### PR TITLE
Adds network switcher to Councils navbar

### DIFF
--- a/apps/councils/components/login.tsx
+++ b/apps/councils/components/login.tsx
@@ -2,9 +2,10 @@
 
 import { councilsChainsList } from '@hatsprotocol/config';
 import { usePrivy } from '@privy-io/react-auth';
+import { useToast } from 'hooks';
 import { toLower } from 'lodash';
 import { createIcon } from 'opepen-standard';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Button, cn, OblongAvatar, Popover, PopoverContent, PopoverTrigger, Skeleton } from 'ui';
 import { chainsMap, formatAddress } from 'utils';
 import { Hex } from 'viem';
@@ -22,6 +23,7 @@ const Login = () => {
     name: ensName as string,
     chainId: 1,
   });
+  const [isLoading, setIsLoading] = useState(false);
 
   const fallbackAvatar = useMemo(() => {
     if (!user || !user.wallet) return undefined;
@@ -31,11 +33,34 @@ const Login = () => {
     }).toDataURL();
   }, [user]);
 
+  const { toast } = useToast();
+
   const handleNetworkSwitch = async (targetChainId: number) => {
+    const currentChain = chainsMap(chainId)?.name ?? 'Unknown Chain';
+    const targetChain = councilsChainsList[targetChainId as keyof typeof councilsChainsList]?.name ?? 'Unknown Chain';
+    setIsLoading(true);
     try {
+      toast({ title: `Switching from ${currentChain} to ${targetChain}...` });
       await switchChain(config, { chainId: targetChainId });
-    } catch (error) {
+      toast({ title: `Successfully switched to ${targetChain}` });
+    } catch (error: unknown) {
       console.error('Failed to switch network:', error);
+
+      // Handle wallet errors based on error properties
+      if (typeof error === 'object' && error !== null) {
+        const walletError = error as { code?: number; message?: string };
+        if (walletError.code === 4902) {
+          toast({ title: `${targetChain} needs to be added to your wallet first` });
+        } else if (walletError.message) {
+          toast({ title: `Failed to switch to ${targetChain}: ${walletError.message}` });
+        } else {
+          toast({ title: `Failed to switch to ${targetChain}` });
+        }
+      } else {
+        toast({ title: `Failed to switch to ${targetChain}` });
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -54,16 +79,18 @@ const Login = () => {
   return (
     <div className='flex items-center gap-1'>
       <Popover>
-        <PopoverTrigger asChild>
+        <PopoverTrigger asChild aria-label='Switch network'>
           <Button className='h-10 w-10 rounded-md border border-gray-200 bg-white p-0 hover:bg-white'>
             {chainId && (
               <img src={chainsMap(chainId)?.iconUrl} alt={chainsMap(chainId)?.name} className='max-w-auto size-7' />
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent className='w-[240px] border border-gray-200 bg-white p-0'>
+        <PopoverContent className='w-[240px] border border-gray-200 bg-white p-0' role='menu'>
           <div className='p-1'>
-            <p className='px-2 py-1.5 text-sm font-medium text-gray-500'>Switch Networks</p>
+            <p className='px-2 py-1.5 text-sm font-medium text-gray-500' id='network-list-title'>
+              Switch Networks
+            </p>
             <div className='flex flex-col gap-1'>
               {Object.entries(councilsChainsList).map(([id, chain]) => (
                 <Button
@@ -73,7 +100,9 @@ const Login = () => {
                     'flex w-full items-center justify-start gap-2 px-2 py-1.5',
                     Number(id) === chainId && 'bg-sky-100',
                   )}
+                  role='menuitem'
                   onClick={() => handleNetworkSwitch(Number(id))}
+                  aria-current={Number(id) === chainId ? 'true' : undefined}
                 >
                   <img src={chain.iconUrl} alt={chain.name} className='size-6' />
                   <span className='text-sm font-medium'>{chain.name}</span>


### PR DESCRIPTION
# Overview

- Closes #1386 
- Adds in a network switcher that takes in the networks in the `councilsChainList` 
- Adds a `bg-sky-100` background to the current network
- Clicking on any chain in the list changes the active network

## Screencap

![councils-network-switcher](https://github.com/user-attachments/assets/791c2114-059f-45d5-af4a-79fa8a5b39c5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The login interface now features interactive network switching via a popover menu.
	- Users can easily select from available networks, with improved feedback mechanisms during the switch process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->