### PR TITLE
Councils/handle pending deploy step

### DIFF
--- a/apps/councils/components/council-create-form/deploy.tsx
+++ b/apps/councils/components/council-create-form/deploy.tsx
@@ -85,7 +85,7 @@ const Deploy = ({ draftId, deployStatus }: { draftId: string; deployStatus: Depl
         </Button>
       </div>
 
-      <div className='flex flex-col gap-4'>
+      <div className='flex flex-col'>
         {Object.entries(deploySteps).map(([key, value], index, array) => {
           const isActive = isActiveStep(key);
           const isComplete = deployStatus[key];
@@ -119,7 +119,7 @@ const Deploy = ({ draftId, deployStatus }: { draftId: string; deployStatus: Depl
                 </div>
 
                 {!isLastStep && (
-                  <div className={cn('my-2 h-3 w-[2px]', isComplete ? 'bg-functional-link-primary' : 'bg-gray-200')} />
+                  <div className={cn('my-2 h-8 w-[2px]', isComplete ? 'bg-functional-link-primary' : 'bg-gray-200')} />
                 )}
               </div>
 


### PR DESCRIPTION
# Overview

- Closes #1427 
- Adds pending animation using the same gradient colors as used in the connectors on the Council Roles step
- If we want in the future we can apply this animation 'rolled up' to the overall steps
- Adds in the vertical decorator between sub-steps
- @scottrepreneur I noticed a redirect error but I'm seeing it on develop too so we may need to address that separately

## Screenshot

![deploy-steps-pending-2](https://github.com/user-attachments/assets/2f676bda-b1b3-48ad-bde4-364173264bae)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the deployment interface with dynamic visual cues that clearly indicate active, complete, and processing steps.
	- Introduced interactive elements and animations that improve clarity and user feedback during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->