### PR TITLE
BUILD-97 BUILD-24: Council Header Polish and Mobile Refactor

### DIFF
--- a/apps/councils/components/council-header.tsx
+++ b/apps/councils/components/council-header.tsx
@@ -43,7 +43,7 @@ const CouncilHeaderCard = ({
   withLinks?: boolean;
 }) => {
   const pathname = usePathname();
-  const isJoinPage = pathname.includes('/join');
+  // const isJoinPage = pathname.includes('/join');
   const isRootPath = pathname === '/';
 
   const { data: councilDetails } = useCouncilDetails({
@@ -152,20 +152,34 @@ const CouncilHeaderCard = ({
               </Button>
             </Link>
           ) : null
-        ) : !isWearing && isJoinPage && !isRootPath && isReadyToClaim ? (
-          <LinkButton
-            href={`/councils/${toLower(chainsMap(chainId ?? 11155111).name)}:${address}/join`}
-            className='w-48 self-center rounded-full md:hidden'
-            variant='outline-blue'
-          >
-            Join Council
-          </LinkButton>
         ) : (
-          <SignersIndicator
-            threshold={toNumber(get(effectiveCouncilDetails, 'minThreshold'))}
-            signers={size(safeSigners)}
-            maxSigners={toNumber(get(primarySignerHat, 'maxSupply'))}
-          />
+          <>
+            {!isWearing && !isRootPath && isReadyToClaim && (
+              <LinkButton
+                href={`/councils/${toLower(chainsMap(chainId ?? 11155111).name)}:${address}/join`}
+                className='w-48 self-center rounded-full md:hidden'
+                variant='outline-blue'
+              >
+                Join Council
+              </LinkButton>
+            )}
+            <div className='hidden md:block'>
+              <SignersIndicator
+                threshold={toNumber(get(effectiveCouncilDetails, 'minThreshold'))}
+                signers={size(safeSigners)}
+                maxSigners={toNumber(get(primarySignerHat, 'maxSupply'))}
+              />
+            </div>
+            {(!isWearing || isRootPath || !isReadyToClaim) && (
+              <div className='md:hidden'>
+                <SignersIndicator
+                  threshold={toNumber(get(effectiveCouncilDetails, 'minThreshold'))}
+                  signers={size(safeSigners)}
+                  maxSigners={toNumber(get(primarySignerHat, 'maxSupply'))}
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
# Overview

- Closes BUILD-97 and BUILD-24
- Refactors `council-header` to work for both mobile and desktop with Tailwind classes and resolves a few spots where we had changed desktop spacing
- Refactors for clarity -- adds more comments and reorganizes slightly 
- Adjusts the logic for when the indicator should be shown on desktop/mobile
- The `isJoinPage` is now commented out since it's not relevant with the Join Council button only showing on mobile but we can add this check back in if we need to hide additional components on the Join page

## Screencaps

![council-header-polish](https://github.com/user-attachments/assets/d6a25331-c6dc-4009-a772-116374ac2d94)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the logic in the council header, altering how join actions are conditionally displayed.
- **Style**
	- Updated the layout of header elements to ensure a more consistent presentation of membership indicators and statistics.
- **Documentation**
	- Improved inline comments for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->