### PR TITLE
BUILD 33: Show the last uncompleted eligibility module by default

### DIFF
--- a/libs/modules-ui/src/module-chain-claim/module-chain-claim-buttons.tsx
+++ b/libs/modules-ui/src/module-chain-claim/module-chain-claim-buttons.tsx
@@ -183,37 +183,40 @@ const ModuleChainClaimButtons = ({
         get(currentEligibility, `[${rule.address}].eligible`) &&
         get(currentEligibility, `[${rule.address}].goodStanding`);
       const isReadyToClaimRule = get(isReadyToClaim, rule.address, false);
+
+      // only consider them Agreement Module complete when fully eligible (not pending)
+      if (rule.module.id.includes('agreement')) {
+        return isEligible;
+      }
+
+      // other modules are complete if eligible or ready to claim
       return isEligible || isReadyToClaimRule;
     },
     [currentEligibility, isReadyToClaim],
   );
 
-  // helper function to check if rule is agreement or subscription
-  const isAgreementOrSubscription = (rule: EligibilityRule) => {
-    return rule.module.id.includes('agreement') || rule.module.id.includes('public-lock-v14');
+  // helper function to check if rule is agreement
+  const isAgreement = (rule: EligibilityRule) => {
+    return rule.module.id.includes('agreement');
   };
 
   // sort rules into three groups:
-  // 1. completed modules
-  const completedRules = flatRules.filter(isRuleCompleted);
+  // 1. completed modules (including completed agreements)
+  const completedRules = flatRules.filter((rule) => isRuleCompleted(rule));
 
-  // 2. incomplete non-agreement/subscription modules
-  const incompleteNormalRules = flatRules.filter((rule) => !isRuleCompleted(rule) && !isAgreementOrSubscription(rule));
+  // 2. incomplete non-agreement modules
+  const incompleteRules = flatRules.filter((rule) => !isAgreement(rule) && !isRuleCompleted(rule));
 
-  // 3. incomplete agreement/subscription modules
-  const incompleteAgreementSubscriptionRules = flatRules.filter(
-    (rule) => !isRuleCompleted(rule) && isAgreementOrSubscription(rule),
-  );
+  // 3. incomplete/pending agreement modules
+  const incompleteAgreementRules = flatRules.filter((rule) => isAgreement(rule) && !isRuleCompleted(rule));
 
-  const sortedRules = concat(completedRules, incompleteNormalRules, incompleteAgreementSubscriptionRules);
+  const sortedRules = concat(completedRules, incompleteRules, incompleteAgreementRules);
 
-  // Always set activeRule to first incomplete module, regardless of sort order
+  // only set initial activeRule if none is selected so that it doesn't override the user selection
   useEffect(() => {
-    const incompleteRule = flatRules.find((rule) => !isRuleCompleted(rule));
-    if (incompleteRule && (!activeRule || isRuleCompleted(activeRule))) {
-      setActiveRule(incompleteRule);
-    } else if (!activeRule) {
-      setActiveRule(first(sortedRules));
+    if (!activeRule) {
+      const incompleteRule = flatRules.find((rule) => !isRuleCompleted(rule));
+      setActiveRule(incompleteRule || first(sortedRules));
     }
   }, [flatRules, activeRule, setActiveRule, sortedRules, isRuleCompleted]);
 

--- a/libs/modules-ui/src/module-chain-claim/module-chain-claim-header.tsx
+++ b/libs/modules-ui/src/module-chain-claim/module-chain-claim-header.tsx
@@ -2,10 +2,10 @@ import { HSG_V2_ABI } from '@hatsprotocol/constants';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEligibility, useOverlay } from 'contexts';
 import { useCouncilDetails, useSafeDetails, useWaitForSubgraph } from 'hooks';
-import { filter, find, first, flatten, get, includes, keys, mapValues, size } from 'lodash';
+import { filter, find, flatten, get, includes, keys, mapValues, size } from 'lodash';
 import { useClaimFn } from 'modules-hooks';
 import posthog from 'posthog-js';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { BsArrowRight, BsCheckSquare, BsCheckSquareFill, BsFillXOctagonFill } from 'react-icons/bs';
 import { AppHat, LabeledModules, ModuleDetails, SupportedChains } from 'types';
 import { Button, LinkButton, Tooltip } from 'ui';
@@ -56,7 +56,7 @@ export const ModuleChainClaimHeader = ({
     currentEligibility,
     isReadyToClaim: aggregateIsReadyToClaim,
     activeRule,
-    setActiveRule,
+
     isWearing,
   } = useEligibility();
   const eligibilityRules = flatten(rawEligibilityRules);
@@ -65,14 +65,6 @@ export const ModuleChainClaimHeader = ({
   // in cases where there's one module to complete the action and claim the hat, it likely has a readyToClaim status
   const completeToClaim = find(keys(aggregateIsReadyToClaim), (v: string) => get(aggregateIsReadyToClaim, v)); // TODO check that this is the only one/not already eligible
   const ruleToCompleteAndClaim = find(eligibilityRules, (rule) => get(rule, 'address') === completeToClaim);
-
-  // useEffect(() => {
-  //   if (activeRule) return;
-
-  //   setActiveRule(first(eligibilityRules));
-  //   // intentionally excluding setActiveRule from the dependency array
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [eligibilityRules, activeRule]);
 
   const {
     handleClaim: originalHandleClaim,


### PR DESCRIPTION
# Overview

- Removes the active eligibility logic from the Council Header and consolidates it into the Buttons
- Adds sorting logic to the buttons

## Screencaps

Before:

![modules-unsorted](https://github.com/user-attachments/assets/9c40f758-0c70-4599-8109-1bd76ad9c65a)

After:

![modules-sorted](https://github.com/user-attachments/assets/7dc9530b-038e-4001-bc7a-097b2a72f64c)
![modules-sorted-default](https://github.com/user-attachments/assets/b45d31d1-0989-4b3f-b3e3-1927d95682c3)
![modules-sorted-default-2](https://github.com/user-attachments/assets/027ed381-78a1-4c43-9569-052ac743f8c9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the display and grouping of eligibility rules in the claim interface for clearer navigation.
  - Updated the default rule selection behavior for a more consistent and intuitive user experience.
  - Streamlined the logic for sorting eligibility rules into distinct categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->