### PR TITLE
BUILD-161: Missing labels on HatWearerStatusForm

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -43,5 +43,3 @@ pnpm serve
 ## Deployment
 
 Having multiple apps that are at different stages of deploy we can choose when to build based on changes in the specific app repo. If there's no changes in an app it won't be built by the CI/CD process. The simplest change is to add (or remove) an extra new line at the end of this file.\
-
-

--- a/libs/forms/src/hat-wearer-status-form.tsx
+++ b/libs/forms/src/hat-wearer-status-form.tsx
@@ -7,7 +7,7 @@ import { toNumber } from 'lodash';
 import { useForm } from 'react-hook-form';
 import { FaRegQuestionCircle, FaRegUserCircle } from 'react-icons/fa';
 import { idToIp, toTreeId } from 'shared';
-import { Button, RadioGroup, RadioGroupItem } from 'ui';
+import { Button, Label, RadioGroup, RadioGroupItem } from 'ui';
 import { formatAddress } from 'utils';
 import { Hex } from 'viem';
 import { useEnsName } from 'wagmi';
@@ -103,10 +103,18 @@ const HatWearerStatusForm = ({
           </p>
         </div>
 
-        <RadioGroup name='standing' defaultValue='Good Standing' onChange={(value) => setValue('standing', value)}>
-          <div className='flex gap-4'>
-            <RadioGroupItem value='Good Standing'>Good Standing</RadioGroupItem>
-            <RadioGroupItem value='Bad Standing'>Bad Standing</RadioGroupItem>
+        <RadioGroup
+          defaultValue='Good Standing'
+          onValueChange={(value) => setValue('standing', value)}
+          className='flex gap-4'
+        >
+          <div className='flex items-center space-x-2'>
+            <RadioGroupItem value='Good Standing' id='good-standing' />
+            <Label htmlFor='good-standing'>Good Standing</Label>
+          </div>
+          <div className='flex items-center space-x-2'>
+            <RadioGroupItem value='Bad Standing' id='bad-standing' />
+            <Label htmlFor='bad-standing'>Bad Standing</Label>
           </div>
         </RadioGroup>
 


### PR DESCRIPTION
# Overview

- Adds labels back in to the `HatWearerStatusForm` 
- Changes `onChange` to `onValueChange` -- Radix/Shad need to use `onValueChange`. This was causing an exception/error. Now works locally without an error

## Considerations

- We have a `RadioBox` implementation that would need some modifications within this form to get working. I didn't want to impact too much and wanted to mainly focus on fixing the missing labels/error. We can likely do a small refactor to support `RadioBox` in the future

## Screencaps

![radio-group-labels-no-error](https://github.com/user-attachments/assets/f810cc76-1c97-41b6-980a-2cd5b5445226)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed extraneous whitespace in documentation for cleaner formatting.
- **New Features**
  - Enhanced the radio selection interface by introducing explicit labels and improved spacing for better accessibility and user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->