### PR TITLE
BUILD-120: Crash when navigating between Hats

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -43,5 +43,3 @@ pnpm serve
 ## Deployment
 
 Having multiple apps that are at different stages of deploy we can choose when to build based on changes in the specific app repo. If there's no changes in an app it won't be built by the CI/CD process. The simplest change is to add (or remove) an extra new line at the end of this file.\
-
-

--- a/libs/modules-ui/src/eligibility-rules/known-eligibility-module.tsx
+++ b/libs/modules-ui/src/eligibility-rules/known-eligibility-module.tsx
@@ -21,6 +21,20 @@ import { UnlockEligibilityRule } from '../subscription';
 import { UnknownEligibilityRule } from './unknown-eligibility';
 
 type WearerEligibility = { [key: Hex]: { eligible: boolean; goodStanding: boolean } };
+
+interface KnownEligibilityModuleParameters {
+  moduleDetails: ModuleDetails | undefined;
+  moduleParameters: ModuleParameter[] | undefined;
+  selectedHat: AppHat | undefined;
+  wearer: Hex | undefined;
+  chainId: SupportedChains | undefined;
+  modalSuffix?: string | undefined;
+  isReadyToClaim?: { [key: Hex]: boolean };
+  setIsReadyToClaim?: (address: Hex) => void;
+  wearerEligibility: WearerEligibility | undefined;
+  ruleSets: Ruleset[] | undefined;
+}
+
 export type EligibilityRuleComponent = ({
   selectedHat,
   moduleDetails,
@@ -31,18 +45,7 @@ export type EligibilityRuleComponent = ({
   isReadyToClaim,
   setIsReadyToClaim,
   ruleSets,
-}: {
-  selectedHat: AppHat | undefined;
-  moduleDetails: ModuleDetails | undefined;
-  moduleParameters: ModuleParameter[] | undefined;
-  wearer: Hex | undefined;
-  chainId: SupportedChains | undefined;
-  modalSuffix?: string | undefined;
-  isReadyToClaim?: { [key: Hex]: boolean };
-  setIsReadyToClaim?: (address: Hex) => void;
-  wearerEligibility: WearerEligibility | undefined;
-  ruleSets: Ruleset[] | undefined;
-}) => ReactNode | undefined;
+}: KnownEligibilityModuleParameters) => ReactNode | undefined;
 
 export const EligibilityModuleRules: {
   [key: string]: EligibilityRuleComponent;
@@ -72,41 +75,33 @@ export const KnownEligibilityModule = ({
   wearerEligibility,
   ruleSets,
 }: KnownEligibilityModuleParameters) => {
+  // if no module details or implementation address, show unknown rule
   if (!moduleDetails?.implementationAddress) {
     return <UnknownEligibilityRule chainId={chainId} wearer={wearer} selectedHat={selectedHat} />;
   }
 
+  // get the module key and validate it exists
   const moduleKey = getKnownEligibilityModule(moduleDetails.implementationAddress as Hex);
-
   if (!moduleKey || !has(EligibilityModuleRules, moduleKey)) {
     return <UnknownEligibilityRule chainId={chainId} wearer={wearer} selectedHat={selectedHat} />;
   }
 
-  const knownRule = EligibilityModuleRules[moduleKey] as EligibilityRuleComponent;
+  // get the rule component
+  const RuleComponent = EligibilityModuleRules[moduleKey];
 
-  return knownRule({
-    selectedHat,
-    moduleDetails,
-    moduleParameters,
-    wearer,
-    chainId,
-    modalSuffix,
-    isReadyToClaim,
-    setIsReadyToClaim,
-    wearerEligibility,
-    ruleSets,
-  });
+  // render the rule as a component with all props available
+  return (
+    <RuleComponent
+      selectedHat={selectedHat}
+      moduleDetails={moduleDetails}
+      moduleParameters={moduleParameters}
+      wearer={wearer}
+      chainId={chainId}
+      modalSuffix={modalSuffix}
+      isReadyToClaim={isReadyToClaim}
+      setIsReadyToClaim={setIsReadyToClaim}
+      wearerEligibility={wearerEligibility}
+      ruleSets={ruleSets}
+    />
+  );
 };
-
-interface KnownEligibilityModuleParameters {
-  moduleDetails: ModuleDetails | undefined;
-  moduleParameters: ModuleParameter[] | undefined;
-  selectedHat: AppHat | undefined;
-  wearer: Hex | undefined;
-  chainId: SupportedChains | undefined;
-  modalSuffix?: string | undefined;
-  isReadyToClaim?: { [key: Hex]: boolean };
-  setIsReadyToClaim?: (address: Hex) => void;
-  wearerEligibility: WearerEligibility | undefined;
-  ruleSets: Ruleset[] | undefined;
-}


### PR DESCRIPTION
# Overview

- Resolves BUILD-120 issue with Hats crashing when navigating between different Hatswith different eligbility modules (with a drawer open)
- Switches to using a component instead of a function for rendering the rules so that React can manage the lifecycle more directly with regard to hook order
- We didn't see this when closing the drawer fully as the Drawer would be unmounted and then a new hook order would be created

## Screencap

![bucket-crash-test](https://github.com/user-attachments/assets/44dd7797-5d64-4768-a93b-62be3a7ad472)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved documentation formatting by removing extraneous blank lines for enhanced readability.

- **Refactor**
  - Streamlined how eligibility rules are handled by consolidating component parameters and clarifying the rendering process while retaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->