### PR TITLE
BUILD-120: Known Toggle Module

### DIFF
--- a/libs/modules-ui/src/eligibility-rules/known-toggle-module.tsx
+++ b/libs/modules-ui/src/eligibility-rules/known-toggle-module.tsx
@@ -2,7 +2,8 @@
 
 import { CONTROLLER_TYPES, TOGGLE_MODULES } from '@hatsprotocol/constants';
 import { Ruleset } from '@hatsprotocol/modules-sdk';
-import { first, pick } from 'lodash';
+import { first, has, pick } from 'lodash';
+import { ReactNode } from 'react';
 import { AppHat, ModuleDetails, SupportedChains } from 'types';
 import { Hex } from 'viem';
 
@@ -10,42 +11,58 @@ import { PassthroughModuleRule } from '../hat-controlled/passthrough-eligibility
 import { SeasonToggleRule } from '../season/season-toggle-rule';
 import { UnknownToggleRule } from './unknown-toggle';
 
-export const KnownToggleModule = ({ ruleSets, chainId, wearer, selectedHat }: KnownModuleParameters) => {
-  const localModule = first(first(ruleSets));
-  const { module: moduleDetails, liveParams: parameters } = pick(localModule, ['module', 'liveParams']);
-
-  switch (moduleDetails?.name) {
-    case TOGGLE_MODULES.season:
-      return (
-        <SeasonToggleRule
-          moduleDetails={moduleDetails as ModuleDetails}
-          moduleParameters={parameters}
-          chainId={chainId}
-          wearer={wearer}
-          selectedHat={selectedHat}
-        />
-      );
-    case TOGGLE_MODULES.passthrough:
-      return (
-        <PassthroughModuleRule
-          moduleDetails={moduleDetails as ModuleDetails}
-          moduleParameters={parameters}
-          chainId={chainId}
-          wearer={wearer}
-          selectedHat={selectedHat}
-          moduleType={CONTROLLER_TYPES.toggle}
-        />
-      );
-  }
-
-  return <UnknownToggleRule chainId={chainId} wearer={wearer} selectedHat={selectedHat} />;
-};
-
 interface KnownModuleParameters {
   ruleSets: Ruleset[] | undefined;
   selectedHat: AppHat | undefined;
   wearer: Hex | undefined;
   chainId: SupportedChains | undefined;
 }
+
+type ToggleRuleComponent = ({
+  moduleDetails,
+  moduleParameters,
+  selectedHat,
+  wearer,
+  chainId,
+}: {
+  moduleDetails: ModuleDetails;
+  moduleParameters: any;
+  selectedHat: AppHat | undefined;
+  wearer: Hex | undefined;
+  chainId: SupportedChains | undefined;
+}) => ReactNode;
+
+const ToggleModuleRules: { [key: string]: ToggleRuleComponent } = {
+  [TOGGLE_MODULES.season]: SeasonToggleRule,
+  [TOGGLE_MODULES.passthrough]: (props) => <PassthroughModuleRule {...props} moduleType={CONTROLLER_TYPES.toggle} />,
+};
+
+export const KnownToggleModule = ({ ruleSets, chainId, wearer, selectedHat }: KnownModuleParameters) => {
+  const localModule = first(first(ruleSets));
+  const { module: moduleDetails, liveParams: parameters } = pick(localModule, ['module', 'liveParams']);
+
+  if (!moduleDetails?.name || !has(ToggleModuleRules, moduleDetails.name)) {
+    return <UnknownToggleRule chainId={chainId} wearer={wearer} selectedHat={selectedHat} />;
+  }
+
+  const RuleComponent = ToggleModuleRules[moduleDetails.name];
+
+  // spread moduleDetails and add liveParameters and instanceAddress
+  const moduleDetailsWithLiveParams: ModuleDetails = {
+    ...moduleDetails,
+    liveParameters: parameters,
+    instanceAddress: localModule?.address,
+  };
+
+  return (
+    <RuleComponent
+      moduleDetails={moduleDetailsWithLiveParams}
+      moduleParameters={parameters}
+      chainId={chainId}
+      wearer={wearer}
+      selectedHat={selectedHat}
+    />
+  );
+};
 
 export default KnownToggleModule;


### PR DESCRIPTION
# Overview

- Refactors `known-toggle-module` to use similar single component pattern that we used in `known-eligibility-module` to initially resolve the issue in BUILD-120
- Single component helps ensure all the modules use a consistent render tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced toggle functionality to dynamically select and render eligible rule components, ensuring a consistent display.
- **Refactor**
	- Simplified the logic behind toggle selection and fallback handling, leading to clearer and more maintainable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->