### PR TITLE
BUILD-214: Adjust z-index for components in Hat Drawer

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -42,4 +42,4 @@ pnpm serve
 
 ## Deployment
 
-Having multiple apps that are at different stages of deploy we can choose when to build based on changes in the specific app repo. If there's no changes in an app it won't be built by the CI/CD process. The simplest change is to add (or remove) an extra new line at the end of this file.\
+Having multiple apps that are at different stages of deploy we can choose when to build based on changes in the specific app repo. If there's no changes in an app it won't be built by the CI/CD process. The simplest change is to add (or remove) an extra new line at the end of this file.

--- a/libs/organisms/src/hat-drawer/top-menu/more-menu.tsx
+++ b/libs/organisms/src/hat-drawer/top-menu/more-menu.tsx
@@ -127,7 +127,7 @@ const MoreMenu = () => {
             </div>
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align='end'>
+        <DropdownMenuContent align='end' className='z-[100]'>
           <div className='gap-5'>
             {/* OFF-CHAIN ACTIONS */}
             <DropdownMenuGroup title='Off-chain Actions'>

--- a/libs/organisms/src/hat-drawer/top-menu/top-menu.tsx
+++ b/libs/organisms/src/hat-drawer/top-menu/top-menu.tsx
@@ -75,7 +75,7 @@ const TopMenu = ({ returnToList }: TopMenuProps) => {
       )}
     >
       {editMode ? (
-        <Tooltip label='Save and return to list'>
+        <Tooltip label='Save and return to list' className='z-[100]'>
           <Button onClick={handleReturnToList} variant='outline' disabled={hatFormLoading}>
             <div className='flex items-center gap-1'>
               <BsArrowLeft className='size-4' />


### PR DESCRIPTION
# Overview

- Increases the `z-index` for the Tooltip used in `top-menu` and the DropdownMenu in `more-menu` 
- These are now visible when the Hat Drawer is open
- Does this by adding an override at the consuming component level via `className` instead of adjusting the base components (Tooltip and Dropdown)

## Screencaps

![hat-drawer-tooltip-z-index](https://github.com/user-attachments/assets/22c7a6d9-470e-4263-98c1-56e99ebdbb48)
![more-menu-z-index](https://github.com/user-attachments/assets/3bad6179-5992-48b7-8390-683cc93183d9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined the "Deployment" section in the documentation by cleaning up extraneous characters for improved clarity.
  
- **Style**
  - Enhanced the visual layering of the dropdown menu.
  - Updated tooltip styling to ensure it displays above overlapping elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->