### PR TITLE
BUILD-274: Update multichain Councils query to include Eth_

### DIFF
--- a/apps/councils/components/council-list-page.tsx
+++ b/apps/councils/components/council-list-page.tsx
@@ -2,20 +2,18 @@
 
 import { councilsChainsList } from '@hatsprotocol/config';
 import { usePrivy } from '@privy-io/react-auth';
-import { useWearerDetails } from 'hats-hooks';
 import {
   useAuthGuard,
-  useCouncilsList,
   useCrossChainAllowlist,
   useCrossChainCouncilsList,
   useCrossChainWearer,
   useMediaStyles,
 } from 'hooks';
-import { concat, flatten, isEmpty, map, uniq } from 'lodash';
+import { flatten, isEmpty, map, uniq } from 'lodash';
 import { ArrowRightCircle } from 'lucide-react';
-import { HatSignerGateV2, SupportedChains } from 'types';
+import { HatSignerGateV2 } from 'types';
 import { Button, Card, HatDeco, Link, Popover, PopoverContent, PopoverTrigger, Skeleton } from 'ui';
-import { chainIdToString, fetchAllowlistEntries, ipfsUrl, logger } from 'utils';
+import { chainIdToString, ipfsUrl } from 'utils';
 import { NETWORKS_PREFIX } from 'utils/src/subgraph/mesh/queries/constants';
 import { getAddress, Hex } from 'viem';
 import { useAccount, useChainId } from 'wagmi';
@@ -43,7 +41,6 @@ const EMPTY_COUNCIL_STEPS = [
 const CouncilListPage = () => {
   const { address: userAddress } = useAccount();
   const { user, login } = usePrivy();
-  const chainId = useChainId();
   const { isClient } = useMediaStyles();
   const { isAuthorized, isReady, needsLogin } = useAuthGuard();
 

--- a/libs/utils/src/subgraph/mesh/fetch/council.ts
+++ b/libs/utils/src/subgraph/mesh/fetch/council.ts
@@ -6,6 +6,7 @@ import { getCrossChainCouncilsListDataQuery, getCrossChainCouncilsListDataQueryD
 
 // TODO: Add Eth_hatsSignerGateV2S back in once subgraph issue is resolved
 interface CrossChainCouncilsResponse {
+  Eth_hatsSignerGateV2S: HatSignerGateV2[];
   Sep_hatsSignerGateV2S: HatSignerGateV2[];
   Op_hatsSignerGateV2S: HatSignerGateV2[];
   Arb_hatsSignerGateV2S: HatSignerGateV2[];

--- a/libs/utils/src/subgraph/mesh/queries/councils.ts
+++ b/libs/utils/src/subgraph/mesh/queries/councils.ts
@@ -5,6 +5,13 @@ import { NETWORKS_PREFIX } from './constants';
 // explicitly query all chains for council data -- TODO: Add Eth_hatsSignerGateV2S back in once subgraph issue is resolved as it currently causes an error in the Mesh response
 export const getCrossChainCouncilsListDataQuery = () => gql`
   query GetCrossChainCouncilsData($hatIds: [ID!]!) {
+    Eth_hatsSignerGateV2S(where: { signerHats_: { id_in: $hatIds } }) {
+      id
+      safe
+      signerHats {
+        id
+      }
+    }
     Sep_hatsSignerGateV2S(where: { signerHats_: { id_in: $hatIds } }) {
       id
       safe

--- a/libs/utils/src/subgraph/mesh/queries/wearers.ts
+++ b/libs/utils/src/subgraph/mesh/queries/wearers.ts
@@ -168,6 +168,9 @@ export function getWearersProfileDetailQuery(chainId: number): string {
 export function getCrossChainAllowlistEligibilitiesQuery(): string {
   return gql`
     query GetCrosschainAllowlistHats($address: String!) {
+      Eth_allowListEligibilities(where: { eligibilityData_: { address: $address } }) {
+        hatId
+      }
       Sep_allowListEligibilities(where: { eligibilityData_: { address: $address } }) {
         hatId
       }
@@ -221,6 +224,40 @@ export function getCrossChainAllowlistEligibilitiesQueryDynamic(): string {
 export function getCrossChainWearerDetailsQuery(): string {
   return gql`
     query GetCrossChainWearerDetails($id: ID!) {
+      Eth_wearer(id: $id) {
+        id
+        currentHats(first: 1000) {
+          id
+          prettyId
+          status
+          createdAt
+          details
+          detailsMetadata
+          maxSupply
+          eligibility
+          toggle
+          mutable
+          imageUri
+          nearestImage
+          levelAtLocalTree
+          claimableBy {
+            id
+          }
+          claimableForBy {
+            id
+          }
+          currentSupply
+          tree {
+            id
+          }
+          wearers {
+            id
+          }
+          admin {
+            id
+          }
+        }
+      }
       Sep_wearer(id: $id) {
         id
         currentHats(first: 1000) {


### PR DESCRIPTION
# Overview

- Adds Eth_ mainnet support back in since Mesh is updated
- Cleans up `councils-list-page.tsx` by removing unused imports and loggers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the councils view by removing unused dependencies for a cleaner, more efficient component.
- **New Features**
  - Expanded data integration to include Ethereum-specific details.
  - Enhanced information retrieval for councils and wearer details, broadening the scope of available data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->