### PR TITLE
BUILD-427: Handle forwarded link in link-button

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -43,3 +43,5 @@ pnpm serve
 ## Deployment
 
 Having multiple apps that are at different stages of deploy we can choose when to build based on changes in the specific app repo. If there's no changes in an app it won't be built by the CI/CD process. The simplest change is to add (or remove) an extra new line at the end of this file.
+
+[//]: # 'DEPLOY_MARKER'

--- a/libs/ui/src/link-button/link-button.tsx
+++ b/libs/ui/src/link-button/link-button.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Button, type ButtonProps } from '../button';
 import { cn } from '../lib/utils';
 
-interface LinkButtonProps extends ButtonProps {
+interface LinkButtonProps extends Omit<ButtonProps, 'asChild'> {
   href?: string;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
@@ -15,57 +15,47 @@ interface LinkButtonProps extends ButtonProps {
   textClassName?: string;
 }
 
-interface BaseLinkButtonProps extends Omit<LinkButtonProps, 'onClick'> {
-  onClick?: React.MouseEventHandler<HTMLAnchorElement> | undefined;
-}
+const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
+  (
+    { href, leftIcon, rightIcon, variant = 'default', children, isExternal, className, textClassName, ...props },
+    ref,
+  ) => {
+    const content = (
+      <div className={cn('flex items-center gap-2')}>
+        {leftIcon}
+        <p className={cn('text-base', textClassName)}>{children}</p>
+        {rightIcon}
+      </div>
+    );
 
-const BaseLinkButton: React.ForwardRefRenderFunction<HTMLAnchorElement, BaseLinkButtonProps> = (
-  { onClick, href, variant, leftIcon, rightIcon, isExternal, size, children, className, textClassName },
-  ref,
-) => {
-  return (
-    <Button variant={variant as ButtonProps['variant']} size={size} className={className} asChild>
-      <a
-        href={href}
-        onClick={onClick}
-        ref={ref}
-        target={isExternal ? '_blank' : undefined}
-        rel={isExternal ? 'noopener noreferrer' : undefined}
-      >
-        <div className={cn('flex items-center gap-2')}>
-          {leftIcon}
-          <p className={cn('text-base', textClassName)}>{children}</p>
-          {rightIcon}
-        </div>
-      </a>
-    </Button>
-  );
-};
+    if (!href) {
+      return (
+        <Button variant={variant} className={className} {...props}>
+          {content}
+        </Button>
+      );
+    }
 
-const ForwardedLinkButton = React.forwardRef(BaseLinkButton);
+    if (isExternal) {
+      return (
+        <Button variant={variant} className={className} asChild {...props}>
+          <a href={href} ref={ref} target='_blank' rel='noopener noreferrer'>
+            {content}
+          </a>
+        </Button>
+      );
+    }
 
-export function LinkButton({
-  href,
-  leftIcon,
-  rightIcon,
-  variant = 'default', // could this be better as `link`?
-  children,
-  onClick,
-  ...props
-}: LinkButtonProps) {
-  if (!href) return null; // TODO handle no href
-  return (
-    // <Link href={href} passHref>
-    <ForwardedLinkButton
-      leftIcon={leftIcon}
-      rightIcon={rightIcon}
-      variant={variant}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onClick={onClick as any}
-      {...props}
-    >
-      {children}
-    </ForwardedLinkButton>
-    // </Link>
-  );
-}
+    return (
+      <Button variant={variant} className={className} asChild {...props}>
+        <Link href={href} ref={ref}>
+          {content}
+        </Link>
+      </Button>
+    );
+  },
+);
+
+LinkButton.displayName = 'LinkButton';
+
+export { LinkButton, type LinkButtonProps };


### PR DESCRIPTION
# Overview

- Resolves BUILD-427
- Removes need for legacyBehavior in link-button by leveraging `asChild` and the Slot in Radix's button -- resolves legacyBehavior issue and fixes the `Create a new tree` button behavior
- This is backwards compatible so we should be good
- Adds a `[//]: # 'DEPLOY_MARKER'` to our README for easier deployment changes since my linter always removes the new line

## Screencap

![CleanShot 2025-04-24 at 17 57 42](https://github.com/user-attachments/assets/82e816b2-cb9f-4f4f-95a4-a6abf195972e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the frontend app's README with a hidden deployment marker.

- **Refactor**
  - Streamlined the LinkButton component for improved maintainability and consistency, with no change to its appearance or usage for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->