### PR TITLE
BUILD-399: Turn off logger in production environments

### DIFF
--- a/libs/utils/src/logs.ts
+++ b/libs/utils/src/logs.ts
@@ -26,10 +26,23 @@ export class ConsoleLogger implements Logger {
     this.levels = ['debug', 'info', 'warn', 'error'];
     this.currentLevel = process.env.NODE_ENV === 'production' ? 'warn' : 'debug';
 
-    this.debug = console.debug.bind(console);
-    this.info = console.info.bind(console);
-    this.warn = console.warn.bind(console);
-    this.error = console.error.bind(console);
+    // Create filtered logging functions
+    this.debug = this.createFilteredLog('debug', console.debug.bind(console));
+    this.info = this.createFilteredLog('info', console.info.bind(console));
+    this.warn = this.createFilteredLog('warn', console.warn.bind(console));
+    this.error = this.createFilteredLog('error', console.error.bind(console));
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return this.levels.indexOf(level) >= this.levels.indexOf(this.currentLevel);
+  }
+
+  private createFilteredLog(level: LogLevel, logFn: LogFn): LogFn {
+    return (...args: any[]) => {
+      if (this.shouldLog(level)) {
+        logFn(...args);
+      }
+    };
   }
 
   setLevel(level: LogLevel): void {
@@ -40,19 +53,6 @@ export class ConsoleLogger implements Logger {
       console.error(`Invalid log level: ${level}`);
     }
   }
-
-  // private _log(level: LogLevel, message: string, ...args: unknown[]): void {
-  //   const levelIndex = this.levels.indexOf(level);
-  //   const currentLevelIndex = this.levels.indexOf(this.currentLevel);
-  //   console.log('levelIndex', levelIndex, currentLevelIndex);
-
-  //   if (levelIndex < currentLevelIndex) return;
-
-  //   const timestamp = new Date().toISOString();
-
-  // TODO couldn't find a good way to preserve source map while injecting level & timestamp
-  //   this[level](`[${level.toUpperCase()}] ${timestamp} -`, message, ...args);
-  // }
 }
 
 export const logger = new ConsoleLogger();


### PR DESCRIPTION
# Overview

- Closes BUILD-399
- I had a previous branch with this on it that also contained several changes where I removed console.logs, but wanted to get this in and keep the diff low so this PR only includes the change to `logger`
- Tested this by building locally and running via `start` and don't see logs whereas I do when running `dev` so we should be good

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how log messages are filtered based on log level, ensuring only relevant messages are shown in the console. No changes to user-facing features or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->