### PR TITLE
BUILD-409: Improve Alignment on Confirm (Deploy) Step

### DIFF
--- a/apps/councils/components/council-create-form/deploy-step/deploy-step.tsx
+++ b/apps/councils/components/council-create-form/deploy-step/deploy-step.tsx
@@ -189,13 +189,14 @@ export const DeployStep = ({ draftId }: { draftId: string }) => {
   return (
     <div className='mx-auto max-w-4xl'>
       <div className='relative border-b border-gray-200 pb-6'>
-        <div className='absolute right-0 top-0'>
-          <Button type='button' variant='outline-blue' rounded='full' onClick={copyUrl}>
-            <Link className='h-4 w-4' /> Share Council Draft
-          </Button>
-        </div>
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='text-3xl font-medium'>{formData.councilName}</h2>
+          <div className='flex w-full items-center justify-between'>
+            <div className='w-[72px]'></div>
+            <h2 className='text-center text-3xl font-medium'>{formData.councilName}</h2>
+            <Button type='button' variant='outline-blue' rounded='full' onClick={copyUrl}>
+              <Link className='h-4 w-4' /> Share
+            </Button>
+          </div>
           <div className='flex gap-1'>
             <span className='text-gray-900'>by</span>{' '}
             <span className='text-gray-500'>

--- a/apps/councils/components/council-create-form/deploy-step/step-summary.tsx
+++ b/apps/councils/components/council-create-form/deploy-step/step-summary.tsx
@@ -10,7 +10,7 @@ interface StepSummaryProps {
 
 export const StepSummary = ({ title, isCompleted, onEdit, children }: StepSummaryProps) => (
   <div className='flex items-start gap-6 border-b border-gray-200 pb-5 pt-3'>
-    <div className='w-[200px] shrink-0 space-y-2'>
+    <div className='w-[160px] shrink-0 space-y-2'>
       <h3 className='text-l font-medium text-gray-900'>{title}</h3>
       <div className='flex items-center gap-1'>
         {isCompleted ? (


### PR DESCRIPTION
# Overview 

- Closes BUILD-409: Adjusts alignment on the header on deploy-step and reduces width for the step summary as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved header layout by centering the council name and aligning the "Share" button to the right, now labeled simply as "Share."
  - Adjusted the width of the step summary container for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->