### PR TITLE
BUILD-478: Narrow query used in the organizations dropdown (DO NOT MERGE)

### DIFF
--- a/apps/councils/components/council-create-form/deploy-step/details-step/details-step.tsx
+++ b/apps/councils/components/council-create-form/deploy-step/details-step/details-step.tsx
@@ -3,17 +3,18 @@
 import { chainsList } from '@hatsprotocol/config';
 import { useCouncilForm } from 'contexts';
 import { ChainSelect, CreatableSelect, Form, Input, Textarea } from 'forms';
-import { useGetOrganizations, useOrganization } from 'hooks';
+import { useGetUserOrganizations, useOrganization } from 'hooks';
 import { isEmpty } from 'lodash';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
 import { StepProps } from 'types';
 import { MemberAvatar } from 'ui';
+import { logger } from 'utils';
+import { useAccount } from 'wagmi';
 
 import { NextStepButton } from '../../../next-step-button';
 import { findNextInvalidStep, getNextStepButtonText } from '../../utils';
 import { LoadingDetailsStep } from './details-skeletons';
-
 interface OrganizationOption {
   value: string;
   label: string;
@@ -33,8 +34,9 @@ const chainOptions: ChainOption[] = Object.values(chainsList).map((chain) => ({
 
 export function DetailsStep({ onNext }: StepProps) {
   const searchParams = useSearchParams();
+  const { address: userAddress } = useAccount();
 
-  const { data: organizationsData, isLoading: isLoadingOrgs } = useGetOrganizations();
+  const { data: organizationsData, isLoading: isLoadingOrgs } = useGetUserOrganizations(userAddress);
 
   // memoize organization options to prevent infinite renders
   const organizationOptions = useMemo(() => {

--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -17,6 +17,7 @@ export * from './use-cross-chain-wearer';
 export * from './use-debounce';
 export * from './use-deep-compare-effect';
 export * from './use-get-organizations';
+export * from './use-get-user-organizations';
 export * from './use-hat-guild-roles';
 export * from './use-hat-snapshot-roles';
 export * from './use-image-uris';

--- a/libs/hooks/src/use-get-user-organizations.ts
+++ b/libs/hooks/src/use-get-user-organizations.ts
@@ -1,0 +1,50 @@
+import { usePrivy } from '@privy-io/react-auth';
+import { usePrefetchQuery, useQuery } from '@tanstack/react-query';
+import { Organization } from 'types';
+import { getUserOrganizations, logger } from 'utils';
+
+interface OrganizationsResponse {
+  organizations: Organization[];
+}
+
+export function useGetUserOrganizations(userAddress: string | undefined) {
+  const { getAccessToken } = usePrivy();
+  const queryKey = ['organizations', userAddress];
+
+  const queryFn = async (): Promise<OrganizationsResponse | null> => {
+    if (!userAddress) {
+      return null;
+    }
+
+    const accessToken = await getAccessToken();
+
+    try {
+      const result = await getUserOrganizations({
+        userAddress: userAddress,
+        accessToken,
+      });
+      logger.info('Raw API response received:', result);
+
+      const typedResult = result as OrganizationsResponse;
+      logger.info('Typed result:', typedResult);
+
+      return typedResult;
+    } catch (error) {
+      logger.error('Error in getUserOrganizations:', error);
+      throw error;
+    }
+  };
+
+  // prefetch the data without triggering a re-render
+  usePrefetchQuery({
+    queryKey,
+    queryFn,
+    staleTime: 0, // always prefetch fresh data
+  });
+
+  return useQuery({
+    queryKey,
+    queryFn,
+    enabled: !!userAddress,
+  });
+}

--- a/libs/utils/src/councils-gql/helpers/form.ts
+++ b/libs/utils/src/councils-gql/helpers/form.ts
@@ -6,7 +6,7 @@ import {
   // UPDATE_COUNCIL_FORM,
   UPDATE_COUNCIL_FORM_WITH_COUNCIL_ID,
 } from '../mutations';
-import { ORGANIZATION_BY_NAME_QUERY, ORGANIZATIONS_QUERY } from '../queries';
+import { GET_USER_ORGANIZATIONS, ORGANIZATION_BY_NAME_QUERY, ORGANIZATIONS_QUERY } from '../queries';
 
 export const addCouncilForForm = async ({
   chainId,
@@ -70,4 +70,14 @@ export const getOrganizationByName = async ({ name, accessToken }: { name: strin
 
 export const getOrganizations = async ({ accessToken }: { accessToken: string | null }) => {
   return getCouncilsGraphqlClient(accessToken ?? undefined).request(ORGANIZATIONS_QUERY);
+};
+
+export const getUserOrganizations = async ({
+  userAddress,
+  accessToken,
+}: {
+  userAddress: string;
+  accessToken: string | null;
+}) => {
+  return getCouncilsGraphqlClient(accessToken ?? undefined).request(GET_USER_ORGANIZATIONS, { userAddress });
 };

--- a/libs/utils/src/councils-gql/queries.ts
+++ b/libs/utils/src/councils-gql/queries.ts
@@ -20,6 +20,15 @@ export const ORGANIZATION_BY_NAME_QUERY = gql`
   ${ORGANIZATION_COUNCIL_FRAGMENT}
 `;
 
+export const GET_USER_ORGANIZATIONS = gql`
+  query GetUserOrganizations($userAddress: String!) {
+    organizations(where: { userAddress: $userAddress }) {
+      ...OrganizationCouncilFragment
+    }
+  }
+  ${ORGANIZATION_COUNCIL_FRAGMENT}
+`;
+
 export const ORGANIZATIONS_QUERY = gql`
   query Organizations {
     organizations {


### PR DESCRIPTION
# Overview

- Closes BUILD-478
- Uses the new, filterable query to narrow the organizations in the dropdown to one's the user is involved with
- We shouldn't merge until the Councils API resolver update is merged/built (works when running the updated API locally)

## Screencaps

![Screenshot 2025-05-07 at 1 54 51 PM](https://github.com/user-attachments/assets/895527ff-e7f5-4f2e-9104-7fffbace4469)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch and display organizations specific to the current user in the council creation process.

- **Bug Fixes**
  - Organizations data is now correctly scoped to the logged-in user, ensuring accurate and relevant information is shown.

- **Chores**
  - Updated internal hooks and utilities to support user-specific organization data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->