### PR TITLE
manage page clean up

### DIFF
--- a/apps/councils/app/councils/[slug]/[page]/page.tsx
+++ b/apps/councils/app/councils/[slug]/[page]/page.tsx
@@ -3,7 +3,7 @@ import { ModuleChainClaim } from 'modules-ui';
 import { redirect } from 'next/navigation';
 import { SupportedChains } from 'types';
 import { Alert, AlertDescription, AlertTitle } from 'ui';
-import { parseCouncilSlug } from 'utils';
+import { logger, parseCouncilSlug } from 'utils';
 import { getAddress, type Hex, isAddress } from 'viem';
 
 import { CouncilsDevInfo } from '../../../../components/councils-dev-info';
@@ -64,6 +64,7 @@ const CouncilDetails = async ({ params }: { params: Promise<{ slug: string; page
     // ensure we have a properly formatted hex address
     validatedAddress = getAddress(address) as `0x${string}`;
   } catch (error) {
+    logger.error('Error validating address', error);
     return (
       <ErrorPage
         title='Invalid Address'

--- a/apps/councils/components/council-create-form/deploy-step/calldata-modal.tsx
+++ b/apps/councils/components/council-create-form/deploy-step/calldata-modal.tsx
@@ -1,13 +1,21 @@
 'use client';
 
 import { MULTICALL3_ADDRESS, ZODIAC_MODULE_PROXY_FACTORY_ADDRESS } from '@hatsprotocol/constants';
-import { HATS_MODULES_FACTORY_ADDRESS } from '@hatsprotocol/modules-sdk';
 import { HATS_V1 } from '@hatsprotocol/sdk-v1-core';
 import { Modal, useCouncilForm, useOverlay } from 'contexts';
 import { useClipboard } from 'hooks';
 import { CopyAddress } from 'icons';
 import { find, map } from 'lodash';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, BaseInput, Button, MemberAvatar } from 'ui';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  BaseInput,
+  Button,
+  Link,
+  MemberAvatar,
+} from 'ui';
 import { getAllWearers } from 'utils';
 import { Hex } from 'viem';
 
@@ -119,7 +127,7 @@ const DeploySecondCouncilCalldata = ({
   );
 };
 
-const CalldataModal = ({ topHatWearer }: { topHatWearer: Hex | undefined }) => {
+const CalldataModal = ({ topHatWearer, draftId }: { topHatWearer: Hex | undefined; draftId: string }) => {
   const { setModals } = useOverlay();
   const { form, deployCouncilCalldata, deployHatsCalldata, deployMchCalldata, deployHsgCalldata, mchArgs } =
     useCouncilForm();
@@ -127,6 +135,10 @@ const CalldataModal = ({ topHatWearer }: { topHatWearer: Hex | undefined }) => {
   const allWearers = getAllWearers(formData);
   const creator = find(allWearers, { address: formData?.creator });
   const owner = find(allWearers, { address: topHatWearer });
+
+  const onClose = () => {
+    setModals?.({});
+  };
 
   return (
     <Modal name='calldata' title='Deploying via Smart Contract' size='xl'>
@@ -175,16 +187,22 @@ const CalldataModal = ({ topHatWearer }: { topHatWearer: Hex | undefined }) => {
           />
         )}
       </div>
-      <div className='flex h-20 items-center justify-center'>
-        <Button
-          variant='outline-blue'
-          rounded='full'
-          onClick={() => {
-            setModals?.({});
-          }}
-        >
-          OK
+
+      <div className='mt-4 flex justify-center'>
+        <p className='text-sm text-gray-500'>
+          After deploying the council, complete the process by processing the transactions.
+        </p>
+      </div>
+
+      <div className='flex h-20 items-center justify-center gap-4'>
+        <Button variant='outline-blue' rounded='full' onClick={onClose}>
+          Close
         </Button>
+        <Link href={`/councils/new/finish?draftId=${draftId}`}>
+          <Button rounded='full' onClick={onClose}>
+            Finish
+          </Button>
+        </Link>
       </div>
     </Modal>
   );

--- a/apps/councils/components/council-create-form/deploy-step/deploy-step.tsx
+++ b/apps/councils/components/council-create-form/deploy-step/deploy-step.tsx
@@ -451,7 +451,7 @@ export const DeployStep = ({ draftId }: { draftId: string }) => {
                 </Tooltip>
               )}
 
-              <CalldataModal topHatWearer={topHatWearer} />
+              <CalldataModal topHatWearer={topHatWearer} draftId={draftId} />
               <PaymentDetailsModal form={form} draftId={draftId} canEdit={canEdit} />
             </div>
           </>

--- a/apps/councils/components/eligibility-rules-dev-info.tsx
+++ b/apps/councils/components/eligibility-rules-dev-info.tsx
@@ -93,21 +93,14 @@ const ModuleParamsDevDisplay = ({
   params: ModuleParameter[] | undefined;
   chainId: number;
 }) => {
-  console.log(params);
   const tokenParam = find(params, { displayType: 'erc20' });
   const tokenAddress = tokenParam?.value as Hex;
-  console.log(tokenAddress, tokenParam, chainId);
-  const {
-    data: tokenDecimals,
-    status,
-    error,
-  } = useReadContract({
+  const { data: tokenDecimals } = useReadContract({
     address: tokenAddress,
     abi: erc20Abi,
     functionName: 'decimals',
     chainId,
   });
-  console.log(tokenDecimals, status, error);
 
   return (
     <div className='flex flex-col items-end gap-1'>

--- a/apps/councils/components/manage-page.tsx
+++ b/apps/councils/components/manage-page.tsx
@@ -197,15 +197,15 @@ export const ManagePage = ({ slug }: { slug: string }) => {
   const isDev = posthog.isFeatureEnabled('dev') || process.env.NODE_ENV !== 'production';
 
   return (
-    <div className='mx-auto flex gap-4 px-4 pt-10 lg:max-w-[1000px]'>
-      <div className='hidden w-1/5 md:flex'>
+    <div className='mx-auto flex gap-20 px-4 pt-10 lg:max-w-[1000px]'>
+      <div className='hidden w-1/3 justify-end md:flex'>
         <SectionMenu
           sections={menuOptions}
           isLoading={councilDetailsLoading || !councilDetails || eligibilityRulesLoading}
         />
       </div>
 
-      <div className='flex w-full flex-col gap-10 px-2 md:w-4/5 md:px-0'>
+      <div className='flex w-full flex-col gap-10 px-2 md:w-2/3 md:px-0'>
         <div className='flex flex-col gap-4' id='threshold'>
           {typeof window === 'undefined' || councilDetailsLoading ? (
             <div className='flex flex-col gap-6'>

--- a/apps/councils/components/modules/agreement-manager.tsx
+++ b/apps/councils/components/modules/agreement-manager.tsx
@@ -137,7 +137,7 @@ const AgreementManager = ({ m, chainId, offchainCouncilDetails, primarySignerHat
       <div className='space-y-4'>
         <div className='space-y-1'>
           {isAdminHat ? (
-            <h2 className='font-medium'>Delegated to Council Managers</h2>
+            <h2 className='font-medium'>Delegated to Organization Managers</h2>
           ) : (
             <h2 className='font-bold'>Agreement Managers</h2>
           )}
@@ -169,7 +169,7 @@ const AgreementManager = ({ m, chainId, offchainCouncilDetails, primarySignerHat
 
                 {userIsAdmin && (
                   <div className='relative'>
-                    <Tooltip label={isAdminHat ? 'Soon you can replace the council managers' : undefined}>
+                    <Tooltip label={isAdminHat ? 'Soon you can replace the organization managers' : undefined}>
                       <span className='pointer-events-auto inline-block'>
                         <Button
                           variant='outline-blue'

--- a/apps/councils/components/modules/allowlist-manager.tsx
+++ b/apps/councils/components/modules/allowlist-manager.tsx
@@ -68,6 +68,7 @@ const AllowlistManager = ({
     selectedHat: managerHat,
     chainId: chainId as SupportedChains,
   });
+
   const userIsAdmin = useIsAdmin({ address: userAddress as Hex, hatId: primarySignerHat, chainId });
   // const hatDetails = managerHat?.detailsMetadata;
   // const hatName = hatDetails ? get(JSON.parse(hatDetails), 'data.name') : undefined;
@@ -154,7 +155,7 @@ const AllowlistManager = ({
         <div className='space-y-4'>
           <div className='space-y-1'>
             {isAdminHat ? (
-              <h2 className='font-medium'>Delegated to Council Managers</h2>
+              <h2 className='font-medium'>Delegated to Organization Managers</h2>
             ) : (
               <h2 className='font-bold'>Compliance Managers</h2>
             )}

--- a/libs/contexts/src/council-form.tsx
+++ b/libs/contexts/src/council-form.tsx
@@ -549,7 +549,7 @@ export function CouncilFormProvider({ children, draftId }: { children: React.Rea
           }
       }
 
-      logger.debug('payload', payload);
+      // logger.debug('payload', payload);
       const accessToken = await getAccessToken();
       const councilsGraphqlClient = getCouncilsGraphqlClient(accessToken ?? undefined);
 
@@ -603,7 +603,7 @@ export function CouncilFormProvider({ children, draftId }: { children: React.Rea
             ? JSON.stringify(formData.completedOptionalSteps)
             : JSON.stringify([]),
       };
-      logger.debug('full payload', newPayload);
+      // logger.debug('full payload', newPayload);
 
       // return await councilsGraphqlClient.request(UPDATE_COUNCIL_FORM, newPayload as Partial<CreationForm>);
       // the payload we are sending has the formatting we need

--- a/libs/contexts/src/eligibility-context.tsx
+++ b/libs/contexts/src/eligibility-context.tsx
@@ -50,9 +50,11 @@ export const EligibilityContext = createContext<EligibilityContextProps>({
   hatterIsAdmin: false,
   // current active rule
   activeRule: undefined,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setActiveRule: (rule: EligibilityRule | undefined) => undefined,
   // in-app eligibility
   isReadyToClaim: {},
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setIsReadyToClaim: (address: Hex) => undefined,
 });
 
@@ -108,11 +110,12 @@ export const EligibilityContextProvider = ({
   });
   const isWearing = balanceOf ? balanceOf > BigInt(0) : false;
 
-  const { claimableForHats, hatterIsAdmin } = useMultiClaimsHatterCheck({
+  const { claimableForHats, hatterIsAdmin, instanceAddress, mchV2 } = useMultiClaimsHatterCheck({
     selectedHatId: selectedHat?.id,
     chainId,
     onchainHats: get(treeDetails, 'hats', []),
   });
+  console.log('instance', { instanceAddress, mchV2 });
   const isClaimableFor = useMemo(() => includes(claimableForHats, selectedHat?.id), [claimableForHats, selectedHat]);
 
   const setIsReadyToClaim = useCallback(

--- a/libs/contexts/src/pro-hooks/use-council-deploy-calldata.ts
+++ b/libs/contexts/src/pro-hooks/use-council-deploy-calldata.ts
@@ -2,11 +2,11 @@
 
 import { CONFIG } from '@hatsprotocol/config';
 import { MULTICALL3_ADDRESS, ZODIAC_MODULE_PROXY_FACTORY_ADDRESS } from '@hatsprotocol/constants';
-import { FALLBACK_ADDRESS, hatIdDecimalToHex, HATS_V1, treeIdToTopHatId } from '@hatsprotocol/sdk-v1-core';
+import { FALLBACK_ADDRESS, HATS_V1 } from '@hatsprotocol/sdk-v1-core';
 import { Tree } from '@hatsprotocol/sdk-v1-subgraph';
 import { useQuery } from '@tanstack/react-query';
 import { useToast } from 'hooks';
-import { pick, toNumber } from 'lodash';
+import { first, get, pick, toNumber } from 'lodash';
 import { useMultiClaimsHatterCheck } from 'modules-hooks';
 import showdown from 'showdown';
 import { CouncilFormData, SupportedChains } from 'types';
@@ -22,7 +22,7 @@ import {
   pinFileToIpfs,
   simulateSafeAddress,
 } from 'utils';
-import { hexToNumber } from 'viem';
+import { Hex } from 'viem';
 
 const converter = new showdown.Converter();
 
@@ -44,7 +44,7 @@ const useCouncilDeployCalldata = ({ formData, tree, treeLoading }: UseCouncilDep
     isLoading: isLoadingMultiClaimsHatterCheck,
   } = useMultiClaimsHatterCheck({
     chainId: toNumber(formData.chain?.value) as SupportedChains,
-    selectedHatId: tree?.id ? hatIdDecimalToHex(treeIdToTopHatId(hexToNumber(tree.id))) : undefined,
+    selectedHatId: tree?.hats ? get(first(tree.hats), 'id') : undefined,
     onchainHats: tree?.hats,
   });
 
@@ -90,7 +90,7 @@ const useCouncilDeployCalldata = ({ formData, tree, treeLoading }: UseCouncilDep
       formData,
       hatIds: computedHatIds,
       agreementCid,
-      existingMch: instanceAddress,
+      existingMch: instanceAddress as Hex,
       mchV2,
     })
       .then(async ({ callData: modulesCalldata, addresses: moduleAddresses, moduleArgs, mchArgs, mchCallData }) => {
@@ -212,8 +212,9 @@ const useCouncilDeployCalldata = ({ formData, tree, treeLoading }: UseCouncilDep
       });
   };
 
+  // TODO move function outside of the hook
   const { data, isLoading, error } = useQuery({
-    queryKey: ['council-deploy-calldata', { formData, tree, instanceAddress }],
+    queryKey: ['council-deploy-calldata', { formData, tree, instanceAddress, mchV2 }],
     queryFn: computeCalldata,
     enabled: !!formData && !treeLoading && !isLoadingMultiClaimsHatterCheck,
   });

--- a/libs/forms/src/claims-handler.tsx
+++ b/libs/forms/src/claims-handler.tsx
@@ -13,6 +13,7 @@ import { idToIp } from 'shared';
 import { AppHat } from 'types';
 import { Button, Tooltip } from 'ui';
 import { formatAddress } from 'utils';
+import { logger } from 'utils';
 import { Hex } from 'viem/_types/types/misc';
 import { useWriteContract } from 'wagmi';
 
@@ -53,7 +54,7 @@ const ClaimsHandler = ({ localForm, onOpenModuleDrawer, setIsStandAloneHatterDep
 
   const hatToMintTo = watch('hatToMintTo');
   const { availableAdmins, hatToMintPended, pendMintHatForHatter } = usePendHatterMint({
-    address: instanceAddress,
+    address: instanceAddress as Hex,
     hatToMintTo: hatToMintTo?.value,
     treeToDisplay,
     selectedHat,
@@ -72,12 +73,13 @@ const ClaimsHandler = ({ localForm, onOpenModuleDrawer, setIsStandAloneHatterDep
   }));
 
   const onSuccess = () => {
-    console.log('success');
+    // TODO handle success (invalidate queries)
+    logger.info('success');
   };
 
   const registerHat = () => {
     if (!instanceAddress || !selectedHat?.id) {
-      console.log('no instance address or selected hat id', {
+      logger.error('no instance address or selected hat id', {
         instanceAddress,
         selectedHat,
       });
@@ -92,7 +94,6 @@ const ClaimsHandler = ({ localForm, onOpenModuleDrawer, setIsStandAloneHatterDep
       chainId,
     })
       .then((hash) => {
-        console.log({ hash });
         handlePendingTx?.({
           hash,
           txChainId: chainId,
@@ -102,7 +103,7 @@ const ClaimsHandler = ({ localForm, onOpenModuleDrawer, setIsStandAloneHatterDep
         });
       })
       .catch((error) => {
-        console.log('error', error);
+        logger.error('Error registering hat', error);
       });
   };
 

--- a/libs/forms/src/components/duration-input.tsx
+++ b/libs/forms/src/components/duration-input.tsx
@@ -5,7 +5,7 @@ import { Info } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { RegisterOptions, UseFormReturn } from 'react-hook-form';
 import { FaRegQuestionCircle } from 'react-icons/fa';
-import { BaseSelect, BaseSelectContent, BaseSelectItem, BaseSelectTrigger, Tooltip } from 'ui';
+import { BaseSelect, BaseSelectContent, BaseSelectItem, BaseSelectTrigger, cn, Tooltip } from 'ui';
 
 import { FormControl, FormDescription, FormLabel } from './form';
 import { NumberInput } from './number-input';
@@ -24,7 +24,6 @@ const DurationInput: React.FC<DurationInputProps> = ({
   name,
   localForm,
   placeholder,
-  isRequired,
   formOptions,
   label,
   labelNote,
@@ -57,6 +56,8 @@ const DurationInput: React.FC<DurationInputProps> = ({
     if (!timeUnit) {
       reset({ [`${name}-time-unit`]: defaultTimeUnit, [`${name}-time-value`]: defaultTimeValue });
     }
+    // intentionally not including `reset` in the dependency array
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, timeUnit, defaultTimeUnit, defaultTimeValue]);
 
   const getVariantStyles = (variant: DurationInputProps['variant'] = 'default') => {
@@ -66,14 +67,14 @@ const DurationInput: React.FC<DurationInputProps> = ({
           label: 'font-bold normal-case text-base',
           description: 'text-gray-400',
           container: 'flex items-center justify-between w-full',
-          tooltipContainer: 'max-w-md',
+          tooltipContainer: 'max-w-md z-50',
         };
       default:
         return {
           label: 'font-normal uppercase',
           description: '',
           container: 'flex items-center gap-1',
-          tooltipContainer: 'max-w-xs',
+          tooltipContainer: 'max-w-xs z-50',
         };
     }
   };
@@ -94,7 +95,7 @@ const DurationInput: React.FC<DurationInputProps> = ({
                   <Tooltip
                     label={tooltip}
                     delayDuration={100}
-                    className={getVariantStyles(variant).tooltipContainer}
+                    className={cn(getVariantStyles(variant).tooltipContainer)}
                     side={variant === 'councils' ? 'bottom' : 'top'}
                   >
                     {variant === 'councils' ? (
@@ -128,7 +129,7 @@ const DurationInput: React.FC<DurationInputProps> = ({
                 onValueChange={(value: any) => setValue(`${name}-time-unit`, value)}
               >
                 <BaseSelectTrigger className='bg-gray-50'>{timeUnit}</BaseSelectTrigger>
-                <BaseSelectContent>
+                <BaseSelectContent className='z-[100]'>
                   {timeUnits.map(({ unit, value }) => (
                     <BaseSelectItem key={unit} value={unit}>
                       {unit}

--- a/libs/hats-hooks/package.json
+++ b/libs/hats-hooks/package.json
@@ -20,6 +20,7 @@
     "@hatsprotocol/sdk-v1-core": "^0.12.4",
     "@hatsprotocol/sdk-v1-subgraph": "^1.1.0",
     "@tanstack/react-query": "^5.64.2",
+    "graphql-request": "^6.1.0",
     "lodash": "^4.17.21",
     "posthog-js": "^1.235.6",
     "react-hook-form": "^7.54.2",

--- a/libs/hats-hooks/src/use-all-wearers.ts
+++ b/libs/hats-hooks/src/use-all-wearers.ts
@@ -1,25 +1,66 @@
 import { useQuery } from '@tanstack/react-query';
-import { flatten, map, range, toNumber } from 'lodash';
+import { GraphQLClient } from 'graphql-request';
+import { flatten, get, map, range, toNumber } from 'lodash';
 import { AppHat, HatWearer, SupportedChains } from 'types';
-import { createSubgraphClient } from 'utils';
+import { NETWORKS_PREFIX } from 'utils';
+// import { createSubgraphClient } from 'utils';
 import { Hex } from 'viem';
 
 // TODO move to utils
-const fetchHatWearersPage = async ({ hatId, chainId, page }: { hatId: Hex; chainId: number; page: number }) => {
-  const subgraphClient = createSubgraphClient();
+// const fetchHatWearersPage = async ({ hatId, chainId, page }: { hatId: Hex; chainId: number; page: number }) => {
+//   const subgraphClient = createSubgraphClient();
 
-  const res = await subgraphClient.getWearersOfHatPaginated({
-    chainId,
-    hatId: BigInt(hatId),
-    props: {},
-    page,
-    perPage: 1000,
+//   const res = await subgraphClient.getWearersOfHatPaginated({
+//     chainId,
+//     hatId: BigInt(hatId),
+//     props: {},
+//     page,
+//     perPage: 1000,
+//   });
+
+//   return res;
+// };
+
+const FETCH_HAT_WEARERS_PAGE_QUERY = (chainId: number) => `
+  query GetWearersOfHatPage($hatId: ID!, $first: Int!, $skip: Int!) {
+    ${NETWORKS_PREFIX[chainId]}_wearers(first: $first, skip: $skip, where: { currentHats_: { id_in: [$hatId] } }) {
+      id
+    }
+  }
+`;
+
+const fetchHatWearersPageMesh = async ({ hatId, chainId, page }: { hatId: Hex; chainId: number; page: number }) => {
+  const meshClient = new GraphQLClient(`${process.env.NEXT_PUBLIC_MESH_API}/graphql` as string);
+
+  const res = await meshClient.request(FETCH_HAT_WEARERS_PAGE_QUERY(chainId), {
+    hatId,
+    first: 1000,
+    skip: page * 1000,
   });
 
-  return res;
+  return get(res, `${NETWORKS_PREFIX[chainId]}_wearers`) as unknown as HatWearer[];
 };
 
-// TODO migrate to use mesh
+const fetchAllWearers = async ({
+  selectedHat,
+  chainId,
+  supply,
+}: {
+  selectedHat: AppHat | undefined;
+  chainId: SupportedChains | undefined;
+  supply: number | undefined;
+}) => {
+  if (!chainId || !selectedHat || !supply) return [];
+  const pages = Math.ceil(supply / 1000);
+  const promises = map(range(pages), (page: number) => {
+    return fetchHatWearersPageMesh({ hatId: selectedHat?.id, chainId, page });
+  });
+
+  const result = await Promise.all(promises);
+
+  return flatten(result) as HatWearer[];
+};
+
 const useAllWearers = ({
   selectedHat,
   chainId,
@@ -29,28 +70,16 @@ const useAllWearers = ({
   chainId: SupportedChains | undefined;
   enabled?: boolean;
 }) => {
-  const supply = toNumber(selectedHat?.currentSupply);
-
-  const fetchAllWearers = async () => {
-    if (!chainId || !selectedHat || !supply) return [];
-    const pages = Math.ceil(supply / 1000);
-    const promises = map(range(pages), (page: number) => {
-      return fetchHatWearersPage({ hatId: selectedHat?.id, chainId, page });
-    });
-
-    const result = await Promise.all(promises);
-
-    return flatten(result) as HatWearer[];
-  };
+  const supply = toNumber(selectedHat?.currentSupply) ?? 0;
 
   const { data, error, isLoading } = useQuery({
-    queryKey: ['allWearers', selectedHat?.id],
-    queryFn: fetchAllWearers,
+    queryKey: ['allWearers', { selectedHat, chainId, supply }],
+    queryFn: () => fetchAllWearers({ selectedHat, chainId, supply }),
     enabled: enabled && !!selectedHat?.id && !!chainId,
     staleTime: 1000 * 60 * 60 * 6, // 6 hours
   });
 
-  return { wearers: data, error, isLoading };
+  return { wearers: data || (selectedHat?.wearers as HatWearer[]), error, isLoading };
 };
 
 export { useAllWearers };

--- a/libs/modules-hooks/src/use-claim-fn.ts
+++ b/libs/modules-hooks/src/use-claim-fn.ts
@@ -76,7 +76,7 @@ export const useClaimFn = ({
       .then((result) => {
         return result;
       })
-      .catch((err) => console.log(err));
+      .catch((err) => logger.error('Error claiming hat', err));
   }, [claimHatFor, address]);
 
   // TODO handle check which module to enable each hook
@@ -99,7 +99,7 @@ export const useClaimFn = ({
     moduleParameters,
     moduleDetails,
     chainId,
-    mchAddress,
+    mchAddress: mchAddress as Hex,
     onSuccessfulSign: () => {
       setStatus(CLAIM_STATUS.SUCCESS);
       onSuccess?.();

--- a/libs/modules-hooks/src/use-module-deploy.ts
+++ b/libs/modules-hooks/src/use-module-deploy.ts
@@ -207,7 +207,7 @@ const useModuleDeploy = ({
   const { writeAsync: deployModuleAndRegisterWithClaimsHatter, isLoading: isLoadingMultiClaimsHatter } =
     useMultiClaimsHatterContractWrite({
       functionName: 'setHatClaimabilityAndCreateModule',
-      address: instanceAddress,
+      address: instanceAddress as Hex,
       enabled: !!instanceAddress && !some(deployModuleAndRegisterWithClaimsHatterArgs, isUndefined),
       args: deployModuleAndRegisterWithClaimsHatterArgs,
       chainId,

--- a/libs/modules-hooks/src/use-multi-claims-hatter-check.ts
+++ b/libs/modules-hooks/src/use-multi-claims-hatter-check.ts
@@ -2,66 +2,109 @@ import { CONFIG } from '@hatsprotocol/config';
 import { Module } from '@hatsprotocol/modules-sdk';
 import { hatIdDecimalToIp } from '@hatsprotocol/sdk-v1-core';
 import { useQuery } from '@tanstack/react-query';
+import { GraphQLClient } from 'graphql-request';
 import { useIsAdmin } from 'hats-hooks';
-import { compact, concat, filter, findIndex, first, flatMap, get, includes, isEmpty, map, uniq } from 'lodash';
+import {
+  compact,
+  concat,
+  filter,
+  find,
+  // findIndex,
+  flatMap,
+  flatten,
+  get,
+  includes,
+  isEmpty,
+  map,
+  orderBy,
+  uniq,
+} from 'lodash';
 import { useMemo } from 'react';
 import { AppHat, FormData, ModuleDetails, SupportedChains } from 'types';
-import { createSubgraphClient, fetchWearerDetails } from 'utils';
+import { fetchWearerDetails, NETWORKS_PREFIX } from 'utils';
 import { Hex } from 'viem';
 
 import { useModuleDetails } from './use-module-details';
 import { useModulesDetails } from './use-modules-details';
 
-const fetchHattersHelper = async (chainId: number, hats: Hex[]) => {
+// const fetchHattersHelper = async (chainId: number, hats: Hex[]) => {
+//   if (isEmpty(hats)) return [];
+
+//   const subgraphClient = createSubgraphClient();
+//   const res = subgraphClient.getHatsByIds({
+//     chainId,
+//     hatIds: hats.map((hat) => BigInt(hat)),
+//     props: {
+//       claimableBy: { props: {} },
+//       claimableForBy: { props: {} },
+//     },
+//   });
+
+//   return res as unknown as Promise<AppHat[]>;
+// };
+
+const FETCH_HATTERS_HELPER_MESH = (chainId: number) => `
+  query getHatsByIds($hatIds: [ID!]!) {
+    ${NETWORKS_PREFIX[chainId]}_hats(where: { id_in: $hatIds }) {
+      id
+      claimableBy {
+        id
+      }
+      claimableForBy {
+        id
+      }
+    }
+  }
+`;
+
+const fetchHattersHelperMesh = async (chainId: number, hats: Hex[]): Promise<AppHat[]> => {
   if (isEmpty(hats)) return [];
 
-  const subgraphClient = createSubgraphClient();
-  const res = subgraphClient.getHatsByIds({
-    chainId,
-    hatIds: hats.map((hat) => BigInt(hat)),
-    props: {
-      claimableBy: { props: {} },
-      claimableForBy: { props: {} },
-    },
+  const client = new GraphQLClient(`${process.env.NEXT_PUBLIC_MESH_API}/graphql` as string);
+  const result = await client.request(FETCH_HATTERS_HELPER_MESH(chainId), {
+    hatIds: hats,
   });
-
-  return res as unknown as Promise<AppHat[]>;
+  return get(result, `${NETWORKS_PREFIX[chainId]}_hats`) as unknown as Promise<AppHat[]>;
 };
 
 const fetchHatters = async (chainId: number | undefined, allHatIds: Hex[] | undefined) => {
   if (!chainId || !allHatIds || isEmpty(allHatIds)) return undefined;
-  const result = await fetchHattersHelper(chainId, allHatIds);
+  const result = await fetchHattersHelperMesh(chainId, allHatIds);
   return result;
 };
 
 const getHatterHat = async (
   claimsHatterData: AppHat[] | undefined,
-  storedModuleDetails: Module[] | undefined,
+  moduleDetails: Module[] | undefined,
   storedData: Partial<FormData>[] | undefined,
   chainId: number | undefined,
 ) => {
   if (!chainId) return {};
 
-  const onchainHatId = first(compact(map(claimsHatterData, 'claimableBy[0].id')));
-
-  const claimsHatterV1Index = findIndex(
-    storedModuleDetails,
-    (result: Module) => get(result, 'implementationAddress') === CONFIG.modules.claimsHatterV1,
+  // Should be reliable to get the most recent version
+  const sortedModules = orderBy(moduleDetails, 'version', 'desc');
+  const claimsHatter = find(sortedModules, (result: Module) =>
+    includes([CONFIG.modules.claimsHatterV2, CONFIG.modules.claimsHatterV1], get(result, 'implementationAddress')),
   );
-  const claimsHatterV2Index = findIndex(
-    storedModuleDetails,
-    (result: Module) => get(result, 'implementationAddress') === CONFIG.modules.claimsHatterV2,
-  );
-  const storedDataHatId = get(storedData, `[${claimsHatterV1Index}].id`);
-  const storedDataHatIdV3 = get(storedData, `[${claimsHatterV2Index}].id`);
+  const address = claimsHatter?.id;
 
-  const address = onchainHatId || storedDataHatId || storedDataHatIdV3;
+  // const claimsHatterV2Index = findIndex(
+  //   moduleDetails,
+  //   (result: Module) => get(result, 'implementationAddress') === CONFIG.modules.claimsHatterV2,
+  // );
+  // const claimsHatterV1Index = findIndex(
+  //   moduleDetails,
+  //   (result: Module) => get(result, 'implementationAddress') === CONFIG.modules.claimsHatterV1,
+  // );
+  // TODO should we be passing these hat IDs here? https://linear.app/hats-protocol/issue/BUILD-123/deploying-a-second-claims-hatter-in-a-tree-complicates-things
+  // const storedDataHatId = get(storedData, `[${claimsHatterV1Index}].id`);
+  // const storedDataHatIdV2 = get(storedData, `[${claimsHatterV2Index}].id`);
 
   if (address) {
-    const result = await fetchWearerDetails(address, chainId);
+    const hatterWearer = await fetchWearerDetails(address, chainId);
 
     return {
-      wearingHat: get(result, 'currentHats.[0].id'),
+      wearingHat: get(hatterWearer, 'currentHats.[0].id'),
       instanceAddress: address,
     };
   }
@@ -94,6 +137,19 @@ const useMultiClaimsHatterCheck = ({
     staleTime: editMode ? Infinity : 1000 * 60 * 15, // 15 minutes
   });
 
+  const allHatters = useMemo(() => {
+    if (!claimsHatterData) return [];
+    return uniq(
+      flatten(
+        map(claimsHatterData, (h) => {
+          return flatten(concat(map(get(h, 'claimableBy'), 'id'), map(get(h, 'claimableForBy'), 'id')));
+        }),
+      ),
+    );
+  }, [claimsHatterData]);
+
+  // console.log('claimsHatterData', claimsHatterData, allHatters);
+
   const claimableHats: Hex[] | undefined = useMemo(() => {
     if (!claimsHatterData) return undefined;
 
@@ -118,7 +174,7 @@ const useMultiClaimsHatterCheck = ({
   );
 
   const { modulesDetails, isLoading: modulesLoading } = useModulesDetails({
-    moduleIds: storedAddresses,
+    moduleIds: concat(allHatters, storedAddresses) as Hex[],
     chainId,
     editMode,
   });
@@ -155,21 +211,21 @@ const useMultiClaimsHatterCheck = ({
     staleTime: editMode ? Infinity : 1000 * 60 * 15, // 15 minutes
   });
 
-  const { details } = useModuleDetails({
-    address: hatterHat?.instanceAddress,
+  const { details: mchDetails } = useModuleDetails({
+    address: hatterHat?.instanceAddress as Hex,
     chainId,
   });
   const hatterIsAdmin = useIsAdmin({
-    address: hatterHat?.instanceAddress,
+    address: hatterHat?.instanceAddress as Hex,
     hatId: selectedHatId as Hex,
     chainId,
   });
 
   return {
-    multiClaimsHatter: details,
+    multiClaimsHatter: mchDetails,
     wearingHat: hatterHat?.wearingHat,
     instanceAddress: hatterHat?.instanceAddress,
-    mchV2: details?.implementationAddress === CONFIG.modules.claimsHatterV2,
+    mchV2: mchDetails?.implementationAddress === CONFIG.modules.claimsHatterV2,
     hatterIsAdmin,
     currentHatIsClaimable,
     claimableHats: hats,

--- a/libs/modules-ui/src/agreement/agreement-claims.tsx
+++ b/libs/modules-ui/src/agreement/agreement-claims.tsx
@@ -8,7 +8,7 @@ import { capitalize, flatten, get, includes, map, size, some, toNumber } from 'l
 import { useAgreementClaim } from 'modules-hooks';
 import { AgreementContent } from 'molecules';
 import { useMemo } from 'react';
-import { BsCheckCircleFill, BsCheckSquare, BsCheckSquareFill } from 'react-icons/bs';
+import { BsCheckCircleFill, BsCheckSquareFill } from 'react-icons/bs';
 import { EligibilityRule, HatDetails, LabeledModules, ModuleDetails } from 'types';
 import { Button, Card, cn, Tooltip } from 'ui';
 import { fetchIpfs } from 'utils';
@@ -137,12 +137,7 @@ interface AgreementClaimsProps {
   variant?: 'default' | 'councils';
 }
 
-export const AgreementClaims = ({
-  activeModule,
-  labeledModules,
-  showOnMobile = false,
-  variant = 'default',
-}: AgreementClaimsProps) => {
+export const AgreementClaims = ({ activeModule, showOnMobile = false, variant = 'default' }: AgreementClaimsProps) => {
   const { selectedHatDetails, selectedHat, eligibilityRules } = useEligibility();
 
   const { agreement } = useAgreementClaim({

--- a/libs/organisms/src/module-drawer/main-content/permissionless-claiming-form.tsx
+++ b/libs/organisms/src/module-drawer/main-content/permissionless-claiming-form.tsx
@@ -32,7 +32,7 @@ const PermissionlessClaimingForm = ({ localForm, parentHats }: { localForm: UseF
   });
 
   const isAdmin = useIsAdmin({
-    address: instanceAddress,
+    address: instanceAddress as Hex,
     hatId: selectedHat?.id,
     chainId,
   });

--- a/libs/types/src/hat.ts
+++ b/libs/types/src/hat.ts
@@ -56,7 +56,6 @@ export interface AppHat extends HatWithMetadata {
   nearestImage?: string;
   detailsObject?: {
     type: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: HatDetails;
   };
   name?: string;

--- a/libs/utils/src/councils/form.ts
+++ b/libs/utils/src/councils/form.ts
@@ -404,7 +404,7 @@ export const compileModuleData = async ({
     args: [implementations, moduleHatIds, immutableArgs, initArgs, saltNonces],
   });
 
-  const claimableTypes = map(claimableHats, () => 2);
+  const claimableTypes = map(claimableHats, () => 2); // TODO handle other claimability type(s)
   const registerAndCreateModulesCalldata = encodeFunctionData({
     abi: mchV2 ? MULTI_CLAIMS_HATTER_V2_ABI : MULTI_CLAIMS_HATTER_V1_ABI,
     functionName: 'setHatsClaimabilityAndCreateModules',

--- a/libs/utils/src/mesh/helpers.ts
+++ b/libs/utils/src/mesh/helpers.ts
@@ -34,7 +34,6 @@ export const getCouncilData = async ({ id, chainId }: { id: string; chainId: num
     ],
   });
 
-  // TODO handle other chains
   return first(get(result, `${networkPrefix}_hatsSignerGateV2S`, undefined));
 };
 

--- a/libs/utils/src/subgraph/hat.ts
+++ b/libs/utils/src/subgraph/hat.ts
@@ -3,6 +3,7 @@ import { AppHat, SupportedChains } from 'types';
 
 import { createSubgraphClient } from '../web3';
 
+// ! currently not used
 export const fetchHatDetails = async (hatId: string | undefined, chainId?: number): Promise<AppHat | null> => {
   if (!hatId || hatId === '0x' || !chainId) return null;
 

--- a/libs/utils/src/subgraph/wearer.ts
+++ b/libs/utils/src/subgraph/wearer.ts
@@ -7,6 +7,7 @@ import { AppHat, HatWearer } from 'types';
 import { Hex } from 'viem';
 
 import { checkAddressIsContract } from '../contract';
+import { logger } from '../logs';
 import { createSubgraphClient, viemPublicClient } from '../web3';
 import { parseMetadata } from './mesh/fetch/utils';
 import { fetchWearerDetailsMesh } from './mesh/fetch/wearer';
@@ -80,6 +81,7 @@ export const fetchWearerDetails = async (address: Hex | string | undefined, chai
       },
     });
   } catch (err) {
+    logger.error('Error fetching wearer details', err);
     return undefined;
   }
 
@@ -101,6 +103,7 @@ export const fetchWearerDetailsForChain = async (address: string | undefined, ch
       return Promise.resolve(withProcessedMetadata);
     })
     .catch((err) => {
+      logger.error('Error fetching wearer details for chain', err);
       return Promise.resolve([]);
     });
 };
@@ -117,7 +120,7 @@ export const fetchWearerDetailsForAllChains = async (address: string | undefined
   });
 };
 
-export const fetchPaginatedWearersForHat = async (hatId: string, chainId: number, page: number = 0) => {
+export const fetchPaginatedWearersForHat = async (hatId: string, chainId: number, page = 0) => {
   const subgraphClient = createSubgraphClient();
 
   const res = await subgraphClient.getWearersOfHatPaginated({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,6 +813,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.64.2
         version: 5.74.11(react@18.3.1)
+      graphql-request:
+        specifier: ^6.1.0
+        version: 6.1.0(encoding@0.1.13)(graphql@16.11.0)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -22879,7 +22882,7 @@ snapshots:
 
   extension-port-stream@3.0.0:
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.10.0
 
   external-editor@3.1.0:


### PR DESCRIPTION
Closes BUILD-520, BUILD-472
- Fixes for getting the current mch address
- Adds some additional error logging (consider adding sentry manual pushes)
- Handles navigating to Finish step
- Move a couple more queries to use the mesh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added "Finish" button and improved instructions to the deployment modal for council creation, allowing users to complete the process with a dedicated finish page link.
- **Bug Fixes**
	- Improved error logging for address validation and wearer detail fetching, providing clearer feedback when issues occur.
- **Style**
	- Updated layout proportions on the manage page for better visual balance.
	- Adjusted z-index layering and tooltip styling in duration input fields.
- **Refactor**
	- Switched data fetching for hat wearers and modules to use a new GraphQL Mesh API, improving reliability and scalability.
	- Updated terminology from "Council Managers" to "Organization Managers" for consistency across components.
- **Chores**
	- Added the "graphql-request" dependency.
	- Removed unused debug logs and cleaned up comments for improved code clarity.
- **Documentation**
	- Updated inline comments and removed obsolete ESLint directives for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->