### PR TITLE
BUILD-514: tooltips hiding on Anchor

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -44,4 +44,4 @@ pnpm serve
 
 Having multiple apps that are at different stages of deploy we can choose when to build based on changes in the specific app repo. If there's no changes in an app it won't be built by the CI/CD process. The simplest change is to add (or remove) an extra new line at the end of this file.
 
-[//]: # 'DEPLOY_MARKER'
+[//]: # 'DEPLOY_MARKERR'

--- a/libs/ui/src/tooltip/tooltip.tsx
+++ b/libs/ui/src/tooltip/tooltip.tsx
@@ -51,7 +51,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs',
+        'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[200] overflow-hidden rounded-md px-3 py-1.5 text-xs',
         className,
       )}
       {...props}


### PR DESCRIPTION
# Overview

- Closes BUILD-514
- Changes the Tooltip UI component to use a `z-[100]` by default instead of the `z-50` -- we changed to this value at other parts of Anchor, so doing at this level now should surface reliably
- We can then use any overrides to adjust if we need, but this covers more of our bases and should improve UX by ensuring no tooltips are hidden in Anchor

## Screencaps

![anchor-tooltips](https://github.com/user-attachments/assets/b2974b91-688b-4bb8-826f-e351ebb6fc25)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased the z-index of tooltips to ensure they appear above other elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->