### PR TITLE
Update subgraph check to use endpoint

### DIFF
--- a/apps/frontend/app/api/subgraph-check/[chainId]/route.ts
+++ b/apps/frontend/app/api/subgraph-check/[chainId]/route.ts
@@ -1,0 +1,94 @@
+import { ANCILLARY_API_URL, NETWORK_ENDPOINTS } from '@hatsprotocol/config';
+import { gql, GraphQLClient } from 'graphql-request';
+import { get, last, split, toNumber } from 'lodash';
+import { SupportedChains } from 'types';
+import { logger, viemPublicClient } from 'utils';
+
+const OUT_OF_SYNC_THRESHOLD = 50;
+
+const SUBGRAPH_BLOCK_QUERY = gql`
+  query SubgraphBlockQuery {
+    _meta {
+      block {
+        number
+      }
+    }
+  }
+`;
+
+interface SubgraphCheckResult {
+  mainSubgraph: number | undefined;
+  mainSubgraphOutOfSync: boolean;
+  mainVersion: string | undefined;
+  ancillarySubgraph: number | undefined;
+  ancillarySubgraphOutOfSync: boolean;
+  ancillaryVersion: string | undefined;
+  chain: number;
+}
+
+export async function GET(request: Request, { params }: { params: Promise<{ chainId: string }> }): Promise<Response> {
+  try {
+    const { chainId: chainIdStr } = await params;
+
+    if (!/^\d+$/.test(chainIdStr)) {
+      return Response.json({ error: 'Invalid chainId parameter' }, { status: 400 });
+    }
+
+    const chainId = parseInt(chainIdStr);
+
+    const ancillaryApiUrl = ANCILLARY_API_URL[chainId as SupportedChains];
+    if (!ancillaryApiUrl) {
+      return Response.json({ error: 'Unsupported chain' }, { status: 400 });
+    }
+
+    const subgraphApiUrl = NETWORK_ENDPOINTS[chainId].endpoint;
+    const authToken = process.env.NEXT_PUBLIC_SUBGRAPH_NETWORK_KEY;
+
+    const mainSubgraphClient = new GraphQLClient(subgraphApiUrl, {
+      headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+    });
+    const mainSubgraphPromise = mainSubgraphClient.request(SUBGRAPH_BLOCK_QUERY).catch((err) => {
+      logger.error(err);
+      return null;
+    });
+
+    const ancillarySubgraphClient = new GraphQLClient(ancillaryApiUrl, {
+      headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+    });
+    const ancillarySubgraphPromise = ancillarySubgraphClient.request(SUBGRAPH_BLOCK_QUERY).catch((err) => {
+      logger.error(err);
+      return null;
+    });
+
+    const chainPromise = viemPublicClient(chainId).getBlock();
+
+    const [mainSubgraph, ancillarySubgraph, chain] = await Promise.all([
+      mainSubgraphPromise,
+      ancillarySubgraphPromise,
+      chainPromise,
+    ]);
+
+    const chainNumber = toNumber(get(chain, 'number').toString());
+    const mainSubgraphNumber = get(mainSubgraph, '_meta.block.number');
+    const ancillarySubgraphNumber = get(ancillarySubgraph, '_meta.block.number');
+
+    const result: SubgraphCheckResult = {
+      mainSubgraph: mainSubgraphNumber,
+      mainSubgraphOutOfSync: Boolean(
+        mainSubgraphNumber && chain && chainNumber - mainSubgraphNumber > OUT_OF_SYNC_THRESHOLD,
+      ),
+      mainVersion: last(split(subgraphApiUrl, '/')),
+      ancillarySubgraph: ancillarySubgraphNumber,
+      ancillarySubgraphOutOfSync: Boolean(
+        ancillarySubgraphNumber && chain && chainNumber - ancillarySubgraphNumber > OUT_OF_SYNC_THRESHOLD,
+      ),
+      ancillaryVersion: last(split(ancillaryApiUrl, '/')),
+      chain: chainNumber,
+    };
+
+    return Response.json(result, { status: 200 });
+  } catch (error) {
+    logger.error('Subgraph check error:', error);
+    return Response.json({ error: 'Failed to check subgraph status' }, { status: 500 });
+  }
+}

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./../../dist/apps/frontend/.next/types/routes.d.ts" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -34,6 +34,7 @@
     "react-cmdk": "^1.3.9",
     "react-datepicker": "^4.17.0",
     "react-dom": "18.3.1",
+    "graphql-request": "^7.1.2",
     "tailwind-merge": "^2.2.2",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",

--- a/libs/config/src/subgraph.ts
+++ b/libs/config/src/subgraph.ts
@@ -3,30 +3,25 @@ import { DEFAULT_ENDPOINTS_CONFIG } from '@hatsprotocol/sdk-v1-subgraph';
 import { mapValues } from 'lodash';
 import { SupportedChains } from 'types';
 
-const STUDIO_ENDPOINT = 'https://api.studio.thegraph.com';
-const STUDIO_ID = '55784';
 const GATEWAY_URL = 'https://gateway.thegraph.com/api';
 
 const SUBGRAPH_KEY = process.env.NEXT_PUBLIC_SUBGRAPH_NETWORK_KEY;
 const gatewayNetworkUrl = (id: string) => {
   return `${GATEWAY_URL}/subgraphs/id/${id}`;
 };
-const studioUrl = (name: string, version: string) => {
-  return `${STUDIO_ENDPOINT}/query/${STUDIO_ID}/${name}/${version}`;
-};
 
 const LOCAL_NETWORK_ENDPOINTS: { [key in SupportedChains]: string } = {
   // network
   1: gatewayNetworkUrl('AtrhAMCcVfPbmejxTez3G59Kdfu5tMFoiPsTUjdCzpKx'),
+  10: gatewayNetworkUrl('9nmXXk3ysDVY4sFygWQNQknwiJLCPnrUNzDRw8bxw61q'),
   100: gatewayNetworkUrl('2VPQUuAeS9Xy8VtinpjHRJEMnZS1sqzFQyCHAys1wb5n'),
   137: gatewayNetworkUrl('7MxsRb1p4UQNET8AgrWd93h3GUgeQ7NWrk5SHLEPCxBP'),
-  42161: gatewayNetworkUrl('4CiXQPjzKshBbyK2dgJiknTNWcj8cGUJsopTsXfm5HEk'),
-  10: gatewayNetworkUrl('9nmXXk3ysDVY4sFygWQNQknwiJLCPnrUNzDRw8bxw61q'),
-  42220: gatewayNetworkUrl('GpKseh3Z4nX2X8W5HjQPp5hpSSxPxsaQ3t1KpEjhvz7t'),
   8453: gatewayNetworkUrl('FWeAqrp36QYqv9gDWLwr7em8vtvPnPrmRRQgnBb6QbBs'),
+  42161: gatewayNetworkUrl('4CiXQPjzKshBbyK2dgJiknTNWcj8cGUJsopTsXfm5HEk'),
+  42220: gatewayNetworkUrl('GpKseh3Z4nX2X8W5HjQPp5hpSSxPxsaQ3t1KpEjhvz7t'),
   // testnets
+  84532: gatewayNetworkUrl('ErLvK6LwwsxkRqd8jvDJ258qfxn1hXhjFGnX78rq1g45'),
   11155111: gatewayNetworkUrl('GphqDnDUibK3keP5vNSDgnKxidvLKtdM7j9FA1Lpe6sX'),
-  84532: studioUrl('hats-v1-base-sepolia', 'v0.0.9'),
 };
 
 export const NETWORK_ENDPOINTS: EndpointsConfig = {
@@ -40,13 +35,14 @@ export const NETWORK_ENDPOINTS: EndpointsConfig = {
 export const ANCILLARY_API_URL: {
   [key in SupportedChains]: string | undefined;
 } = {
-  1: studioUrl('hats-v1-ethereum-ancillary', 'v0.0.27'),
-  10: studioUrl('hats-v1-optimism-ancillary', 'v0.0.24'),
-  100: studioUrl('hats-v1-gnosis-chain-ancillary', 'v0.0.24'),
-  137: studioUrl('hats-v1-polygon-ancillary', 'v0.0.24'),
-  8453: studioUrl('hats-v1-base-ancillary', 'v0.0.25'),
-  42161: studioUrl('hats-v1-arbitrum-ancillary', 'v0.0.24'),
-  42220: studioUrl('hats-v1-celo-ancillary', 'v0.0.25'),
-  11155111: studioUrl('hats-v1-sepolia-ancillary', 'v0.0.25'),
-  84532: studioUrl('hats-v1-base-sepolia-ancillary', 'v0.0.1'),
+  1: gatewayNetworkUrl('8PFNN7v8dM9ivLkK33GmxrN9KvQdzj6pPXtnjyPhp3Vz'),
+  10: gatewayNetworkUrl('E4cKJKsrjUgXSwdYZiY2qr6iapiJtzAmvJPNhzB3ZXaU'),
+  100: gatewayNetworkUrl('BW77GmitrJ1fpcQxCh8pD1ByZsYA9RYaTxkb7eQGVUpP'),
+  137: gatewayNetworkUrl('2sgSZBBCoHCJwxHedJ9StP3TfCeWreL7qPKsvNKHCFQ4'),
+  8453: gatewayNetworkUrl('7jZgRG7Jq82Fb1u8jyp5ssMUKBArS2awB5Ntuvr1SG19'),
+  42161: gatewayNetworkUrl('4LLNyDawRxMNeEpnwo2FcZ5cjjt9p6R9QxEK6w1o4xQj'),
+  42220: gatewayNetworkUrl('CRNjnuoxfimapENXiGezHbSoBftKqF3ZnUhqZLaqVXQk'),
+  // testnets
+  84532: gatewayNetworkUrl('J31xpBbw6ydicVAi1wXr5eJpWHVDdeDdk3JZGrxtW7MC'),
+  11155111: gatewayNetworkUrl('CtSNCVK4g2chmnMy29s2FCq14Rup4U9EUDwpQ2NNCPC9'),
 };

--- a/libs/hooks/src/use-subgraph-check.ts
+++ b/libs/hooks/src/use-subgraph-check.ts
@@ -1,62 +1,30 @@
-import { ANCILLARY_API_URL, NETWORK_ENDPOINTS } from '@hatsprotocol/config';
 import { useQuery } from '@tanstack/react-query';
-import { gql, GraphQLClient } from 'graphql-request';
-import { get, last, split, toNumber } from 'lodash';
-import { SupportedChains } from 'types';
-import { logger, viemPublicClient } from 'utils';
 
-const OUT_OF_SYNC_THRESHOLD = 50;
+interface SubgraphCheckResult {
+  mainSubgraph: number | undefined;
+  mainSubgraphOutOfSync: boolean;
+  mainVersion: string | undefined;
+  ancillarySubgraph: number | undefined;
+  ancillarySubgraphOutOfSync: boolean;
+  ancillaryVersion: string | undefined;
+  chain: number;
+}
 
-const SUBGRAPH_BLOCK_QUERY = gql`
-  query SubgraphBlockQuery {
-    _meta {
-      block {
-        number
-      }
+const fetchSubgraphCheck = async (chainId: number): Promise<SubgraphCheckResult | undefined> => {
+  if (!chainId) return;
+
+  try {
+    const response = await fetch(`/api/subgraph-check/${chainId}`);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
     }
+
+    return await response.json();
+  } catch (error) {
+    console.error('Failed to fetch subgraph check:', error);
+    throw error;
   }
-`;
-
-const fetchSubgraphCheck = async (chainId: number) => {
-  const ancillaryApiUrl = ANCILLARY_API_URL[chainId as SupportedChains];
-  if (!chainId || !ancillaryApiUrl) return;
-
-  const subgraphApiUrl = NETWORK_ENDPOINTS[chainId].endpoint;
-  // TODO migrate timeout to abort controller
-  const mainSubgraphClient = new GraphQLClient(subgraphApiUrl);
-  const mainSubgraphPromise = mainSubgraphClient.request(SUBGRAPH_BLOCK_QUERY).catch((err) => {
-    logger.error(err);
-    return null;
-  });
-
-  const ancillarySubgraphClient = new GraphQLClient(ancillaryApiUrl);
-  const ancillarySubgraphPromise = ancillarySubgraphClient.request(SUBGRAPH_BLOCK_QUERY).catch((err) => {
-    logger.error(err);
-    return null;
-  });
-
-  const chainPromise = viemPublicClient(chainId).getBlock();
-
-  const [mainSubgraph, ancillarySubgraph, chain] = await Promise.all([
-    mainSubgraphPromise,
-    ancillarySubgraphPromise,
-    chainPromise,
-  ]);
-
-  const chainNumber = toNumber(get(chain, 'number').toString());
-  const mainSubgraphNumber = get(mainSubgraph, '_meta.block.number');
-  const ancillarySubgraphNumber = get(ancillarySubgraph, '_meta.block.number');
-
-  return {
-    mainSubgraph: mainSubgraphNumber,
-    mainSubgraphOutOfSync: mainSubgraphNumber && chain && chainNumber - mainSubgraphNumber > OUT_OF_SYNC_THRESHOLD,
-    mainVersion: last(split(subgraphApiUrl, '/')),
-    ancillarySubgraph: ancillarySubgraphNumber,
-    ancillarySubgraphOutOfSync:
-      ancillarySubgraphNumber && chain && chainNumber - ancillarySubgraphNumber > OUT_OF_SYNC_THRESHOLD,
-    ancillaryVersion: last(split(ancillaryApiUrl, '/')),
-    chain: chainNumber,
-  };
 };
 
 const useSubgraphCheck = (chainId: number) => {

--- a/libs/hooks/src/use-wait-for-subgraph.ts
+++ b/libs/hooks/src/use-wait-for-subgraph.ts
@@ -1,5 +1,3 @@
-import { NETWORK_ENDPOINTS } from '@hatsprotocol/config';
-import { gql, GraphQLClient } from 'graphql-request';
 import { get, toNumber, toString } from 'lodash';
 import { TransactionReceipt } from 'viem';
 
@@ -7,27 +5,15 @@ import { useToast } from './use-toast';
 
 const SUBGRAPH_WAIT_TIMEOUT = 20_000; // 20 seconds
 
-const quickSubgraphClient = (chainId: number) => {
-  const networkEndpoint = NETWORK_ENDPOINTS[chainId];
-  const client = new GraphQLClient(get(networkEndpoint, 'endpoint'));
-  return client;
-};
-
 const fetchSubgraphBlockNumber = async (chainId: number) => {
-  const subgraphClient = quickSubgraphClient(chainId);
+  const response = await fetch(`/api/subgraph-check/${chainId}`);
 
-  const query = gql`
-    query {
-      _meta {
-        block {
-          number
-        }
-      }
-    }
-  `;
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
 
-  const data = await subgraphClient.request(query);
-  return get(data, '_meta.block.number', null);
+  const data = await response.json();
+  return get(data, 'mainSubgraph', null);
 };
 
 const useWaitForSubgraph = ({
@@ -46,6 +32,7 @@ const useWaitForSubgraph = ({
   const waitForBlock = async (data: TransactionReceipt | undefined) =>
     new Promise((resolve, reject) => {
       const blockNumber = toNumber(toString(get(data, 'blockNumber')));
+      let lastSeenSubgraphBlock: number | null = null;
 
       const checkBlockHandler = async () => {
         if (!chainId || !blockNumber) {
@@ -54,6 +41,8 @@ const useWaitForSubgraph = ({
 
         return fetchSubgraphBlockNumber(chainId)
           .then((subgraphBlockNumber) => {
+            lastSeenSubgraphBlock = subgraphBlockNumber;
+
             if (!subgraphBlockNumber || subgraphBlockNumber < blockNumber) {
               return;
             }
@@ -89,7 +78,16 @@ const useWaitForSubgraph = ({
 
       setTimeout(() => {
         clearInterval(intervalId);
-        return reject(new Error('Subgraph wait timeout'));
+
+        const timeoutMessage = `Subgraph wait timeout - waiting for block ${blockNumber}${lastSeenSubgraphBlock ? `, last seen block ${lastSeenSubgraphBlock}` : ''}`;
+
+        toast({
+          title: 'Subgraph sync timeout',
+          description: `Waited ${waitTimeout / 1000}s for subgraph to reach block ${blockNumber}. Last seen: ${lastSeenSubgraphBlock || 'unknown'}`,
+          variant: 'destructive',
+        });
+
+        return reject(new Error(timeoutMessage));
       }, waitTimeout);
     });
 

--- a/libs/utils/src/web3/chains.ts
+++ b/libs/utils/src/web3/chains.ts
@@ -14,7 +14,6 @@ import {
   metaMaskWallet,
   rabbyWallet,
   rainbowWallet,
-  safeWallet,
   uniswapWallet,
   walletConnectWallet,
   zerionWallet,
@@ -36,8 +35,14 @@ const getWCProjectId = () => {
 };
 
 const getConnectors = () => {
+  // Skip connector initialization during SSR to prevent browser API access
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
   const WC_PROJECT_ID = getWCProjectId();
   if (!WC_PROJECT_ID) {
+    // eslint-disable-next-line no-console
     console.warn('NEXT_PUBLIC_WC_PROJECT_ID not set, wallet connections may not work properly');
     return [];
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       forms:
         specifier: workspace:*
         version: link:../../libs/forms
+      graphql-request:
+        specifier: ^7.1.2
+        version: 7.2.0(graphql@16.6.0)
       hats-hooks:
         specifier: workspace:*
         version: link:../../libs/hats-hooks


### PR DESCRIPTION
Closes BUILD-1252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a REST API to check subgraph health per network, returning sync status, versions, and chain info.
* Refactor
  * Client-side subgraph checks now call the new REST endpoint instead of querying subgraphs directly.
  * Ancillary/gateway subgraph endpoint mappings updated and network coverage expanded.
  * Wallet connector initialization guarded during server-side rendering.
* Chores
  * Added a runtime dependency for GraphQL requests.
* Style
  * Removed the Safe wallet option from the preset list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->